### PR TITLE
Add Word entity

### DIFF
--- a/src/main/java/com/glancy/backend/entity/Word.java
+++ b/src/main/java/com/glancy/backend/entity/Word.java
@@ -1,0 +1,30 @@
+package com.glancy.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "words")
+@Data
+@NoArgsConstructor
+public class Word {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String term;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String definition;
+
+    @Column
+    private String example;
+
+    @Column(nullable = false)
+    private Boolean deleted = false;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+}


### PR DESCRIPTION
## Summary
- add `Word` entity to store vocabulary

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d473c00dc8332a26781b3604ce0e7