### PR TITLE
Extend user profile fields and account binding

### DIFF
--- a/src/main/java/com/glancy/backend/controller/UserController.java
+++ b/src/main/java/com/glancy/backend/controller/UserController.java
@@ -9,6 +9,7 @@ import com.glancy.backend.dto.LoginRequest;
 import com.glancy.backend.dto.LoginResponse;
 import com.glancy.backend.dto.UserRegistrationRequest;
 import com.glancy.backend.dto.UserResponse;
+import com.glancy.backend.dto.ThirdPartyAccountRequest;
 import com.glancy.backend.entity.User;
 import com.glancy.backend.service.UserService;
 
@@ -57,4 +58,13 @@ public class UserController {
         LoginResponse resp = userService.login(req);
         return new ResponseEntity<>(resp, HttpStatus.OK);
     }
-}
+
+    /**
+     * 绑定第三方账号
+     */
+    @PostMapping("/{id}/third-party-accounts")
+    public ResponseEntity<Void> bindThirdParty(@PathVariable Long id,
+                                               @Valid @RequestBody ThirdPartyAccountRequest req) {
+        userService.bindThirdPartyAccount(id, req);
+        return ResponseEntity.ok().build();
+    }}

--- a/src/main/java/com/glancy/backend/dto/LoginRequest.java
+++ b/src/main/java/com/glancy/backend/dto/LoginRequest.java
@@ -10,4 +10,6 @@ public class LoginRequest {
 
     @NotBlank(message = "密码不能为空")
     private String password;
-}
+
+    // Optional device information used during login
+    private String deviceInfo;}

--- a/src/main/java/com/glancy/backend/dto/LoginResponse.java
+++ b/src/main/java/com/glancy/backend/dto/LoginResponse.java
@@ -9,4 +9,5 @@ public class LoginResponse {
     private Long id;
     private String username;
     private String email;
-}
+    private String avatar;
+    private String phone;}

--- a/src/main/java/com/glancy/backend/dto/ThirdPartyAccountRequest.java
+++ b/src/main/java/com/glancy/backend/dto/ThirdPartyAccountRequest.java
@@ -1,0 +1,13 @@
+package com.glancy.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class ThirdPartyAccountRequest {
+    @NotBlank(message = "平台不能为空")
+    private String provider;
+
+    @NotBlank(message = "外部ID不能为空")
+    private String externalId;
+}

--- a/src/main/java/com/glancy/backend/dto/UserRegistrationRequest.java
+++ b/src/main/java/com/glancy/backend/dto/UserRegistrationRequest.java
@@ -16,4 +16,9 @@ public class UserRegistrationRequest {
     @NotBlank(message = "邮箱不能为空")
     @Email(message = "邮箱格式不正确")
     private String email;
-}
+
+    // Optional avatar URL
+    private String avatar;
+
+    // Optional phone number
+    private String phone;}

--- a/src/main/java/com/glancy/backend/dto/UserResponse.java
+++ b/src/main/java/com/glancy/backend/dto/UserResponse.java
@@ -9,4 +9,5 @@ public class UserResponse {
     private Long id;
     private String username;
     private String email;
-}
+    private String avatar;
+    private String phone;}

--- a/src/main/java/com/glancy/backend/entity/LoginDevice.java
+++ b/src/main/java/com/glancy/backend/entity/LoginDevice.java
@@ -1,0 +1,27 @@
+package com.glancy.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "login_devices")
+@Data
+@NoArgsConstructor
+public class LoginDevice {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String deviceInfo;
+
+    @Column(nullable = false)
+    private LocalDateTime loginTime = LocalDateTime.now();
+}

--- a/src/main/java/com/glancy/backend/entity/ThirdPartyAccount.java
+++ b/src/main/java/com/glancy/backend/entity/ThirdPartyAccount.java
@@ -1,0 +1,25 @@
+package com.glancy.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "third_party_accounts")
+@Data
+@NoArgsConstructor
+public class ThirdPartyAccount {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 50)
+    private String provider;
+
+    @Column(nullable = false, length = 100)
+    private String externalId;
+}

--- a/src/main/java/com/glancy/backend/entity/User.java
+++ b/src/main/java/com/glancy/backend/entity/User.java
@@ -22,9 +22,14 @@ public class User {
     @Column(nullable = false, unique = true, length = 100)
     private String email;
 
+    // Optional avatar image URL
+    private String avatar;
+
+    // Optional phone number
+    private String phone;
+
     @Column(nullable = false)
     private Boolean deleted = false;
 
     @Column(nullable = false)
-    private LocalDateTime createdAt = LocalDateTime.now();
-}
+    private LocalDateTime createdAt = LocalDateTime.now();}

--- a/src/main/java/com/glancy/backend/repository/LoginDeviceRepository.java
+++ b/src/main/java/com/glancy/backend/repository/LoginDeviceRepository.java
@@ -1,0 +1,9 @@
+package com.glancy.backend.repository;
+
+import com.glancy.backend.entity.LoginDevice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LoginDeviceRepository extends JpaRepository<LoginDevice, Long> {
+}

--- a/src/main/java/com/glancy/backend/repository/ThirdPartyAccountRepository.java
+++ b/src/main/java/com/glancy/backend/repository/ThirdPartyAccountRepository.java
@@ -1,0 +1,9 @@
+package com.glancy.backend.repository;
+
+import com.glancy.backend.entity.ThirdPartyAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ThirdPartyAccountRepository extends JpaRepository<ThirdPartyAccount, Long> {
+}

--- a/src/main/java/com/glancy/backend/service/UserService.java
+++ b/src/main/java/com/glancy/backend/service/UserService.java
@@ -7,8 +7,13 @@ import com.glancy.backend.dto.LoginRequest;
 import com.glancy.backend.dto.LoginResponse;
 import com.glancy.backend.dto.UserRegistrationRequest;
 import com.glancy.backend.dto.UserResponse;
+import com.glancy.backend.dto.ThirdPartyAccountRequest;
 import com.glancy.backend.entity.User;
+import com.glancy.backend.entity.LoginDevice;
+import com.glancy.backend.entity.ThirdPartyAccount;
 import com.glancy.backend.repository.UserRepository;
+import com.glancy.backend.repository.LoginDeviceRepository;
+import com.glancy.backend.repository.ThirdPartyAccountRepository;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
@@ -16,10 +21,16 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final LoginDeviceRepository loginDeviceRepository;
+    private final ThirdPartyAccountRepository thirdPartyAccountRepository;
     private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
-    public UserService(UserRepository userRepository) {
+    public UserService(UserRepository userRepository,
+                       LoginDeviceRepository loginDeviceRepository,
+                       ThirdPartyAccountRepository thirdPartyAccountRepository) {
         this.userRepository = userRepository;
+        this.loginDeviceRepository = loginDeviceRepository;
+        this.thirdPartyAccountRepository = thirdPartyAccountRepository;
     }
 
     @Transactional
@@ -34,8 +45,11 @@ public class UserService {
         user.setUsername(req.getUsername());
         user.setPassword(passwordEncoder.encode(req.getPassword()));
         user.setEmail(req.getEmail());
+        user.setAvatar(req.getAvatar());
+        user.setPhone(req.getPhone());
         User saved = userRepository.save(user);
-        return new UserResponse(saved.getId(), saved.getUsername(), saved.getEmail());
+        return new UserResponse(saved.getId(), saved.getUsername(), saved.getEmail(),
+                saved.getAvatar(), saved.getPhone());
     }
 
     @Transactional
@@ -70,6 +84,24 @@ public class UserService {
             throw new IllegalArgumentException("密码错误");
         }
 
-        return new LoginResponse(user.getId(), user.getUsername(), user.getEmail());
+        if (req.getDeviceInfo() != null && !req.getDeviceInfo().isEmpty()) {
+            LoginDevice device = new LoginDevice();
+            device.setUser(user);
+            device.setDeviceInfo(req.getDeviceInfo());
+            loginDeviceRepository.save(device);
+        }
+
+        return new LoginResponse(user.getId(), user.getUsername(), user.getEmail(),
+                user.getAvatar(), user.getPhone());
     }
-}
+
+    @Transactional
+    public void bindThirdPartyAccount(Long userId, ThirdPartyAccountRequest req) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("用户不存在"));
+        ThirdPartyAccount account = new ThirdPartyAccount();
+        account.setUser(user);
+        account.setProvider(req.getProvider());
+        account.setExternalId(req.getExternalId());
+        thirdPartyAccountRepository.save(account);
+    }}

--- a/src/test/java/com/glancy/backend/controller/UserControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/UserControllerTest.java
@@ -26,7 +26,7 @@ class UserControllerTest {
 
     @Test
     void testRegister() throws Exception {
-        UserResponse resp = new UserResponse(1L, "testuser", "test@example.com");
+        UserResponse resp = new UserResponse(1L, "testuser", "test@example.com", null, null);
         when(userService.register(any(UserRegistrationRequest.class))).thenReturn(resp);
 
         mockMvc.perform(post("/api/users/register")


### PR DESCRIPTION
## Summary
- add avatar and phone fields to `User` entity
- track login devices and third-party bindings via new entities and repositories
- update DTOs and service logic to handle new fields
- expose endpoint to bind third-party accounts
- adjust tests for new DTO structure

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d44a45ee48332843a6344445a28e0