### PR TITLE
Add user preference entity

### DIFF
--- a/src/main/java/com/glancy/backend/controller/UserPreferenceController.java
+++ b/src/main/java/com/glancy/backend/controller/UserPreferenceController.java
@@ -1,0 +1,33 @@
+package com.glancy.backend.controller;
+
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.glancy.backend.dto.UserPreferenceRequest;
+import com.glancy.backend.dto.UserPreferenceResponse;
+import com.glancy.backend.service.UserPreferenceService;
+
+@RestController
+@RequestMapping("/api/preferences")
+public class UserPreferenceController {
+    private final UserPreferenceService userPreferenceService;
+
+    public UserPreferenceController(UserPreferenceService userPreferenceService) {
+        this.userPreferenceService = userPreferenceService;
+    }
+
+    @PostMapping("/user/{userId}")
+    public ResponseEntity<UserPreferenceResponse> savePreference(@PathVariable Long userId,
+                                                                 @Valid @RequestBody UserPreferenceRequest req) {
+        UserPreferenceResponse resp = userPreferenceService.savePreference(userId, req);
+        return new ResponseEntity<>(resp, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<UserPreferenceResponse> getPreference(@PathVariable Long userId) {
+        UserPreferenceResponse resp = userPreferenceService.getPreference(userId);
+        return ResponseEntity.ok(resp);
+    }
+}

--- a/src/main/java/com/glancy/backend/dto/UserPreferenceRequest.java
+++ b/src/main/java/com/glancy/backend/dto/UserPreferenceRequest.java
@@ -1,0 +1,14 @@
+package com.glancy.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class UserPreferenceRequest {
+    @NotBlank
+    private String theme;
+    @NotBlank
+    private String systemLanguage;
+    @NotBlank
+    private String searchLanguage;
+}

--- a/src/main/java/com/glancy/backend/dto/UserPreferenceResponse.java
+++ b/src/main/java/com/glancy/backend/dto/UserPreferenceResponse.java
@@ -1,0 +1,14 @@
+package com.glancy.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class UserPreferenceResponse {
+    private Long id;
+    private Long userId;
+    private String theme;
+    private String systemLanguage;
+    private String searchLanguage;
+}

--- a/src/main/java/com/glancy/backend/entity/UserPreference.java
+++ b/src/main/java/com/glancy/backend/entity/UserPreference.java
@@ -1,0 +1,28 @@
+package com.glancy.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_preferences")
+@Data
+@NoArgsConstructor
+public class UserPreference {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(nullable = false, length = 20)
+    private String theme;
+
+    @Column(nullable = false, length = 20)
+    private String systemLanguage;
+
+    @Column(nullable = false, length = 20)
+    private String searchLanguage;
+}

--- a/src/main/java/com/glancy/backend/repository/UserPreferenceRepository.java
+++ b/src/main/java/com/glancy/backend/repository/UserPreferenceRepository.java
@@ -1,0 +1,13 @@
+package com.glancy.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.glancy.backend.entity.UserPreference;
+
+import java.util.Optional;
+
+@Repository
+public interface UserPreferenceRepository extends JpaRepository<UserPreference, Long> {
+    Optional<UserPreference> findByUserId(Long userId);
+}

--- a/src/main/java/com/glancy/backend/service/UserPreferenceService.java
+++ b/src/main/java/com/glancy/backend/service/UserPreferenceService.java
@@ -1,0 +1,49 @@
+package com.glancy.backend.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.glancy.backend.dto.UserPreferenceRequest;
+import com.glancy.backend.dto.UserPreferenceResponse;
+import com.glancy.backend.entity.User;
+import com.glancy.backend.entity.UserPreference;
+import com.glancy.backend.repository.UserPreferenceRepository;
+import com.glancy.backend.repository.UserRepository;
+
+@Service
+public class UserPreferenceService {
+    private final UserPreferenceRepository userPreferenceRepository;
+    private final UserRepository userRepository;
+
+    public UserPreferenceService(UserPreferenceRepository userPreferenceRepository,
+                                 UserRepository userRepository) {
+        this.userPreferenceRepository = userPreferenceRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public UserPreferenceResponse savePreference(Long userId, UserPreferenceRequest req) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("用户不存在"));
+        UserPreference pref = userPreferenceRepository.findByUserId(userId)
+                .orElse(new UserPreference());
+        pref.setUser(user);
+        pref.setTheme(req.getTheme());
+        pref.setSystemLanguage(req.getSystemLanguage());
+        pref.setSearchLanguage(req.getSearchLanguage());
+        UserPreference saved = userPreferenceRepository.save(pref);
+        return toResponse(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public UserPreferenceResponse getPreference(Long userId) {
+        UserPreference pref = userPreferenceRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("未找到用户设置"));
+        return toResponse(pref);
+    }
+
+    private UserPreferenceResponse toResponse(UserPreference pref) {
+        return new UserPreferenceResponse(pref.getId(), pref.getUser().getId(),
+                pref.getTheme(), pref.getSystemLanguage(), pref.getSearchLanguage());
+    }
+}

--- a/src/test/java/com/glancy/backend/service/UserPreferenceServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/UserPreferenceServiceTest.java
@@ -1,0 +1,67 @@
+package com.glancy.backend.service;
+
+import com.glancy.backend.dto.UserPreferenceRequest;
+import com.glancy.backend.dto.UserPreferenceResponse;
+import com.glancy.backend.entity.User;
+import com.glancy.backend.repository.UserPreferenceRepository;
+import com.glancy.backend.repository.UserRepository;
+
+import io.github.cdimascio.dotenv.Dotenv;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class UserPreferenceServiceTest {
+
+    @Autowired
+    private UserPreferenceService userPreferenceService;
+    @Autowired
+    private UserPreferenceRepository userPreferenceRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeAll
+    static void loadEnv() {
+        Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+        String dbPassword = dotenv.get("DB_PASSWORD");
+        if (dbPassword != null) {
+            System.setProperty("DB_PASSWORD", dbPassword);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        userPreferenceRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void testSaveAndGetPreference() {
+        User user = new User();
+        user.setUsername("prefuser");
+        user.setPassword("pass");
+        user.setEmail("pref@example.com");
+        userRepository.save(user);
+
+        UserPreferenceRequest req = new UserPreferenceRequest();
+        req.setTheme("light");
+        req.setSystemLanguage("en");
+        req.setSearchLanguage("zh");
+        UserPreferenceResponse saved = userPreferenceService.savePreference(user.getId(), req);
+
+        assertNotNull(saved.getId());
+        assertEquals("light", saved.getTheme());
+
+        UserPreferenceResponse fetched = userPreferenceService.getPreference(user.getId());
+        assertEquals(saved.getId(), fetched.getId());
+        assertEquals("zh", fetched.getSearchLanguage());
+    }
+}


### PR DESCRIPTION
## Summary
- support storing per-user preferences like theme and language
- expose service and controller for user preferences
- add unit test for UserPreferenceService

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d4a51ce888332a9a7a0c728c21689