### PR TITLE
Refine Word entity

### DIFF
--- a/src/main/java/com/glancy/backend/entity/Language.java
+++ b/src/main/java/com/glancy/backend/entity/Language.java
@@ -1,0 +1,11 @@
+package com.glancy.backend.entity;
+
+public enum Language {
+    CHINESE,
+    ENGLISH,
+    JAPANESE,
+    KOREAN,
+    RUSSIAN,
+    GERMAN,
+    FRENCH
+}

--- a/src/main/java/com/glancy/backend/entity/Word.java
+++ b/src/main/java/com/glancy/backend/entity/Word.java
@@ -1,0 +1,38 @@
+package com.glancy.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "words")
+@Data
+@NoArgsConstructor
+public class Word {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String term;
+
+    @ElementCollection
+    @CollectionTable(name = "word_definitions", joinColumns = @JoinColumn(name = "word_id"))
+    @Column(name = "definition", nullable = false, columnDefinition = "TEXT")
+    private List<String> definitions = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private Language language;
+
+    @Column
+    private String example;
+
+    @Column(nullable = false)
+    private Boolean deleted = false;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+}


### PR DESCRIPTION
## Summary
- add `Language` enum for managing supported languages
- update `Word` entity to store multiple definitions and track `language`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d473c00dc8332a26781b3604ce0e7