### PR TITLE
Implement search record management

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,11 @@ Submit contact messages via:
 ```
 POST /api/contact
 ```
-
 The endpoint accepts `name`, `email` and `message` fields and returns the saved record.
+
+## Search Record Endpoints
+
+- `POST /api/search-records/user/{userId}` – add a new search record for the user
+- `GET /api/search-records/user/{userId}` – list search records of the user
+- `DELETE /api/search-records/user/{userId}` – clear all search records of the user
+

--- a/src/main/java/com/glancy/backend/controller/SearchRecordController.java
+++ b/src/main/java/com/glancy/backend/controller/SearchRecordController.java
@@ -1,0 +1,40 @@
+package com.glancy.backend.controller;
+
+import com.glancy.backend.dto.SearchRecordRequest;
+import com.glancy.backend.dto.SearchRecordResponse;
+import com.glancy.backend.service.SearchRecordService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/search-records")
+public class SearchRecordController {
+    private final SearchRecordService searchRecordService;
+
+    public SearchRecordController(SearchRecordService searchRecordService) {
+        this.searchRecordService = searchRecordService;
+    }
+
+    @PostMapping("/user/{userId}")
+    public ResponseEntity<SearchRecordResponse> create(@PathVariable Long userId,
+                                                       @Valid @RequestBody SearchRecordRequest req) {
+        SearchRecordResponse resp = searchRecordService.saveRecord(userId, req);
+        return new ResponseEntity<>(resp, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<SearchRecordResponse>> list(@PathVariable Long userId) {
+        List<SearchRecordResponse> resp = searchRecordService.getRecords(userId);
+        return ResponseEntity.ok(resp);
+    }
+
+    @DeleteMapping("/user/{userId}")
+    public ResponseEntity<Void> clear(@PathVariable Long userId) {
+        searchRecordService.clearRecords(userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/glancy/backend/dto/SearchRecordRequest.java
+++ b/src/main/java/com/glancy/backend/dto/SearchRecordRequest.java
@@ -1,0 +1,15 @@
+package com.glancy.backend.dto;
+
+import com.glancy.backend.entity.Language;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class SearchRecordRequest {
+    @NotBlank(message = "搜索词不能为空")
+    private String term;
+
+    @NotNull(message = "语言不能为空")
+    private Language language;
+}

--- a/src/main/java/com/glancy/backend/dto/SearchRecordResponse.java
+++ b/src/main/java/com/glancy/backend/dto/SearchRecordResponse.java
@@ -1,0 +1,17 @@
+package com.glancy.backend.dto;
+
+import com.glancy.backend.entity.Language;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+public class SearchRecordResponse {
+    private Long id;
+    private Long userId;
+    private String term;
+    private Language language;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/glancy/backend/entity/SearchRecord.java
+++ b/src/main/java/com/glancy/backend/entity/SearchRecord.java
@@ -1,0 +1,31 @@
+package com.glancy.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "search_records")
+@Data
+@NoArgsConstructor
+public class SearchRecord {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 100)
+    private String term;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private Language language;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/src/main/java/com/glancy/backend/repository/SearchRecordRepository.java
+++ b/src/main/java/com/glancy/backend/repository/SearchRecordRepository.java
@@ -1,0 +1,13 @@
+package com.glancy.backend.repository;
+
+import com.glancy.backend.entity.SearchRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SearchRecordRepository extends JpaRepository<SearchRecord, Long> {
+    List<SearchRecord> findByUserIdOrderByCreatedAtDesc(Long userId);
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/glancy/backend/service/SearchRecordService.java
+++ b/src/main/java/com/glancy/backend/service/SearchRecordService.java
@@ -1,0 +1,53 @@
+package com.glancy.backend.service;
+
+import com.glancy.backend.dto.SearchRecordRequest;
+import com.glancy.backend.dto.SearchRecordResponse;
+import com.glancy.backend.entity.SearchRecord;
+import com.glancy.backend.entity.User;
+import com.glancy.backend.repository.SearchRecordRepository;
+import com.glancy.backend.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class SearchRecordService {
+    private final SearchRecordRepository searchRecordRepository;
+    private final UserRepository userRepository;
+
+    public SearchRecordService(SearchRecordRepository searchRecordRepository,
+                               UserRepository userRepository) {
+        this.searchRecordRepository = searchRecordRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public SearchRecordResponse saveRecord(Long userId, SearchRecordRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("用户不存在"));
+        SearchRecord record = new SearchRecord();
+        record.setUser(user);
+        record.setTerm(request.getTerm());
+        record.setLanguage(request.getLanguage());
+        SearchRecord saved = searchRecordRepository.save(record);
+        return toResponse(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SearchRecordResponse> getRecords(Long userId) {
+        return searchRecordRepository.findByUserIdOrderByCreatedAtDesc(userId)
+                .stream().map(this::toResponse).collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void clearRecords(Long userId) {
+        searchRecordRepository.deleteByUserId(userId);
+    }
+
+    private SearchRecordResponse toResponse(SearchRecord record) {
+        return new SearchRecordResponse(record.getId(), record.getUser().getId(),
+                record.getTerm(), record.getLanguage(), record.getCreatedAt());
+    }
+}

--- a/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
@@ -1,0 +1,53 @@
+package com.glancy.backend.controller;
+
+import com.glancy.backend.dto.SearchRecordRequest;
+import com.glancy.backend.dto.SearchRecordResponse;
+import com.glancy.backend.entity.Language;
+import com.glancy.backend.service.SearchRecordService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(SearchRecordController.class)
+class SearchRecordControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private SearchRecordService searchRecordService;
+
+    @Test
+    void testCreate() throws Exception {
+        SearchRecordResponse resp = new SearchRecordResponse(1L, 1L, "hello", Language.ENGLISH, LocalDateTime.now());
+        when(searchRecordService.saveRecord(any(Long.class), any(SearchRecordRequest.class))).thenReturn(resp);
+
+        mockMvc.perform(post("/api/search-records/user/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"term\":\"hello\",\"language\":\"ENGLISH\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.term").value("hello"));
+    }
+
+    @Test
+    void testList() throws Exception {
+        SearchRecordResponse resp = new SearchRecordResponse(1L, 1L, "hello", Language.ENGLISH, LocalDateTime.now());
+        when(searchRecordService.getRecords(1L)).thenReturn(Collections.singletonList(resp));
+
+        mockMvc.perform(get("/api/search-records/user/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].term").value("hello"));
+    }
+}

--- a/src/test/java/com/glancy/backend/service/SearchRecordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/SearchRecordServiceTest.java
@@ -1,0 +1,68 @@
+package com.glancy.backend.service;
+
+import com.glancy.backend.dto.SearchRecordRequest;
+import com.glancy.backend.dto.SearchRecordResponse;
+import com.glancy.backend.entity.Language;
+import com.glancy.backend.entity.User;
+import com.glancy.backend.repository.SearchRecordRepository;
+import com.glancy.backend.repository.UserRepository;
+import io.github.cdimascio.dotenv.Dotenv;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class SearchRecordServiceTest {
+
+    @Autowired
+    private SearchRecordService searchRecordService;
+    @Autowired
+    private SearchRecordRepository searchRecordRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeAll
+    static void loadEnv() {
+        Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+        String dbPassword = dotenv.get("DB_PASSWORD");
+        if (dbPassword != null) {
+            System.setProperty("DB_PASSWORD", dbPassword);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        searchRecordRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void testSaveListAndClear() {
+        User user = new User();
+        user.setUsername("sruser");
+        user.setPassword("p");
+        user.setEmail("s@example.com");
+        userRepository.save(user);
+
+        SearchRecordRequest req = new SearchRecordRequest();
+        req.setTerm("hello");
+        req.setLanguage(Language.ENGLISH);
+        SearchRecordResponse saved = searchRecordService.saveRecord(user.getId(), req);
+        assertNotNull(saved.getId());
+
+        List<SearchRecordResponse> list = searchRecordService.getRecords(user.getId());
+        assertEquals(1, list.size());
+        assertEquals("hello", list.get(0).getTerm());
+
+        searchRecordService.clearRecords(user.getId());
+        assertTrue(searchRecordService.getRecords(user.getId()).isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- add SearchRecord entity/repository/service/controller
- expose endpoints to create/list/clear search records
- document search record endpoints in README
- add unit tests for service and controller

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d4c9d58bc8332a32969e74b22cadb