### PR TITLE
Implement word query feature

### DIFF
--- a/src/main/java/com/glancy/backend/controller/WordController.java
+++ b/src/main/java/com/glancy/backend/controller/WordController.java
@@ -1,0 +1,27 @@
+package com.glancy.backend.controller;
+
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+import com.glancy.backend.service.WordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/words")
+public class WordController {
+    private final WordService wordService;
+
+    public WordController(WordService wordService) {
+        this.wordService = wordService;
+    }
+
+    @GetMapping
+    public ResponseEntity<WordResponse> getWord(@RequestParam String term,
+                                                @RequestParam Language language) {
+        WordResponse resp = wordService.findWord(term, language);
+        return ResponseEntity.ok(resp);
+    }
+}

--- a/src/main/java/com/glancy/backend/dto/WordResponse.java
+++ b/src/main/java/com/glancy/backend/dto/WordResponse.java
@@ -1,0 +1,17 @@
+package com.glancy.backend.dto;
+
+import com.glancy.backend.entity.Language;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class WordResponse {
+    private Long id;
+    private String term;
+    private List<String> definitions;
+    private Language language;
+    private String example;
+}

--- a/src/main/java/com/glancy/backend/repository/WordRepository.java
+++ b/src/main/java/com/glancy/backend/repository/WordRepository.java
@@ -1,0 +1,13 @@
+package com.glancy.backend.repository;
+
+import com.glancy.backend.entity.Language;
+import com.glancy.backend.entity.Word;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface WordRepository extends JpaRepository<Word, Long> {
+    Optional<Word> findByTermAndLanguageAndDeletedFalse(String term, Language language);
+}

--- a/src/main/java/com/glancy/backend/service/WordService.java
+++ b/src/main/java/com/glancy/backend/service/WordService.java
@@ -1,0 +1,29 @@
+package com.glancy.backend.service;
+
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+import com.glancy.backend.entity.Word;
+import com.glancy.backend.repository.WordRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class WordService {
+    private final WordRepository wordRepository;
+
+    public WordService(WordRepository wordRepository) {
+        this.wordRepository = wordRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public WordResponse findWord(String term, Language language) {
+        Word word = wordRepository.findByTermAndLanguageAndDeletedFalse(term, language)
+                .orElseThrow(() -> new IllegalArgumentException("单词不存在"));
+        return toResponse(word);
+    }
+
+    private WordResponse toResponse(Word word) {
+        return new WordResponse(word.getId(), word.getTerm(), word.getDefinitions(),
+                word.getLanguage(), word.getExample());
+    }
+}

--- a/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -1,0 +1,40 @@
+package com.glancy.backend.controller;
+
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+import com.glancy.backend.service.WordService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(WordController.class)
+class WordControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private WordService wordService;
+
+    @Test
+    void testGetWord() throws Exception {
+        WordResponse resp = new WordResponse(1L, "hello", List.of("g"), Language.ENGLISH, "ex");
+        when(wordService.findWord(eq("hello"), eq(Language.ENGLISH))).thenReturn(resp);
+
+        mockMvc.perform(get("/api/words")
+                        .param("term", "hello")
+                        .param("language", "ENGLISH")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.term").value("hello"));
+    }
+}

--- a/src/test/java/com/glancy/backend/service/WordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/WordServiceTest.java
@@ -1,0 +1,54 @@
+package com.glancy.backend.service;
+
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+import com.glancy.backend.entity.Word;
+import com.glancy.backend.repository.WordRepository;
+import io.github.cdimascio.dotenv.Dotenv;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class WordServiceTest {
+    @Autowired
+    private WordService wordService;
+    @Autowired
+    private WordRepository wordRepository;
+
+    @BeforeAll
+    static void loadEnv() {
+        Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+        String dbPassword = dotenv.get("DB_PASSWORD");
+        if (dbPassword != null) {
+            System.setProperty("DB_PASSWORD", dbPassword);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        wordRepository.deleteAll();
+    }
+
+    @Test
+    void testFindWord() {
+        Word w = new Word();
+        w.setTerm("hello");
+        w.setDefinitions(List.of("greeting"));
+        w.setLanguage(Language.ENGLISH);
+        w.setExample("Hello world");
+        Word saved = wordRepository.save(w);
+
+        WordResponse resp = wordService.findWord("hello", Language.ENGLISH);
+        assertEquals(saved.getId(), resp.getId());
+        assertEquals("greeting", resp.getDefinitions().get(0));
+    }
+}


### PR DESCRIPTION
## Summary
- add `WordResponse` DTO
- create `WordRepository` and `WordService`
- provide `/api/words` endpoint in `WordController`
- add service and controller tests for words

## Testing
- `./mvnw test` *(fails: Network is unreachable while downloading Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_686d51e3dad483329fb9b5ee41cfb2b9