### PR TITLE
Improve third-party account binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ java -jar target/glancy-backend-0.0.1-SNAPSHOT.jar
 - `DELETE /api/users/{id}` – logically delete a user
 - `GET /api/users/{id}` – fetch user details
 - `POST /api/users/login` – user login
-- `POST /api/users/{id}/third-party-accounts` – bind a third‑party account
+- `POST /api/users/{id}/third-party-accounts` – bind a third‑party account (returns the bound account)
 
 ### Notifications
 - `POST /api/notifications/system` – create a system notification

--- a/src/main/java/com/glancy/backend/controller/UserController.java
+++ b/src/main/java/com/glancy/backend/controller/UserController.java
@@ -10,6 +10,7 @@ import com.glancy.backend.dto.LoginResponse;
 import com.glancy.backend.dto.UserRegistrationRequest;
 import com.glancy.backend.dto.UserResponse;
 import com.glancy.backend.dto.ThirdPartyAccountRequest;
+import com.glancy.backend.dto.ThirdPartyAccountResponse;
 import com.glancy.backend.entity.User;
 import com.glancy.backend.service.UserService;
 
@@ -63,8 +64,8 @@ public class UserController {
      * 绑定第三方账号
      */
     @PostMapping("/{id}/third-party-accounts")
-    public ResponseEntity<Void> bindThirdParty(@PathVariable Long id,
-                                               @Valid @RequestBody ThirdPartyAccountRequest req) {
-        userService.bindThirdPartyAccount(id, req);
-        return ResponseEntity.ok().build();
-    }}
+    public ResponseEntity<ThirdPartyAccountResponse> bindThirdParty(@PathVariable Long id,
+                                               @Valid @RequestBody ThirdPartyAccountRequest req) {        ThirdPartyAccountResponse resp = userService.bindThirdPartyAccount(id, req);
+        return new ResponseEntity<>(resp, HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/glancy/backend/dto/ThirdPartyAccountResponse.java
+++ b/src/main/java/com/glancy/backend/dto/ThirdPartyAccountResponse.java
@@ -1,0 +1,13 @@
+package com.glancy.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ThirdPartyAccountResponse {
+    private Long id;
+    private String provider;
+    private String externalId;
+    private Long userId;
+}

--- a/src/main/java/com/glancy/backend/repository/ThirdPartyAccountRepository.java
+++ b/src/main/java/com/glancy/backend/repository/ThirdPartyAccountRepository.java
@@ -3,7 +3,9 @@ package com.glancy.backend.repository;
 import com.glancy.backend.entity.ThirdPartyAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import java.util.Optional;
 
 @Repository
 public interface ThirdPartyAccountRepository extends JpaRepository<ThirdPartyAccount, Long> {
+    Optional<ThirdPartyAccount> findByProviderAndExternalId(String provider, String externalId);
 }

--- a/src/test/java/com/glancy/backend/controller/UserControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/UserControllerTest.java
@@ -86,7 +86,8 @@ class UserControllerTest {
 
     @Test
     void bindThirdParty() throws Exception {
-        doNothing().when(userService).bindThirdPartyAccount(eq(1L), any(ThirdPartyAccountRequest.class));
+        ThirdPartyAccountResponse resp = new ThirdPartyAccountResponse(1L, "p", "e", 1L);
+        when(userService.bindThirdPartyAccount(eq(1L), any(ThirdPartyAccountRequest.class))).thenReturn(resp);
 
         ThirdPartyAccountRequest req = new ThirdPartyAccountRequest();
         req.setProvider("p");
@@ -95,5 +96,6 @@ class UserControllerTest {
         mockMvc.perform(post("/api/users/1/third-party-accounts")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(req)))
-                .andExpect(status().isOk());
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1L));
     }}


### PR DESCRIPTION
## Summary
- implement `ThirdPartyAccountResponse` DTO
- return created response from `bindThirdPartyAccount`
- check if third-party account already bound
- update controller endpoint to return 201 with bound account
- adjust README and tests

## Testing
- `./mvnw test -q` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d519b95a883329498229d7cd6a34b