### PR TITLE
Implement daily search limit for non-members

### DIFF
--- a/src/main/java/com/glancy/backend/controller/WordController.java
+++ b/src/main/java/com/glancy/backend/controller/WordController.java
@@ -1,8 +1,10 @@
 package com.glancy.backend.controller;
 
 import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.dto.SearchRecordRequest;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.service.WordService;
+import com.glancy.backend.service.SearchRecordService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,14 +15,22 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/words")
 public class WordController {
     private final WordService wordService;
+    private final SearchRecordService searchRecordService;
 
-    public WordController(WordService wordService) {
+    public WordController(WordService wordService,
+                          SearchRecordService searchRecordService) {
         this.wordService = wordService;
+        this.searchRecordService = searchRecordService;
     }
 
     @GetMapping
-    public ResponseEntity<WordResponse> getWord(@RequestParam String term,
+    public ResponseEntity<WordResponse> getWord(@RequestParam Long userId,
+                                                @RequestParam String term,
                                                 @RequestParam Language language) {
+        SearchRecordRequest req = new SearchRecordRequest();
+        req.setTerm(term);
+        req.setLanguage(language);
+        searchRecordService.saveRecord(userId, req);
         WordResponse resp = wordService.findWord(term, language);
         return ResponseEntity.ok(resp);
     }

--- a/src/main/java/com/glancy/backend/entity/User.java
+++ b/src/main/java/com/glancy/backend/entity/User.java
@@ -31,5 +31,7 @@ public class User {
     @Column(nullable = false)
     private Boolean deleted = false;
 
+    @Column(nullable = false)    private Boolean member = false;
+
     @Column(nullable = false)
     private LocalDateTime createdAt = LocalDateTime.now();}

--- a/src/main/java/com/glancy/backend/repository/SearchRecordRepository.java
+++ b/src/main/java/com/glancy/backend/repository/SearchRecordRepository.java
@@ -5,9 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.time.LocalDateTime;
 
 @Repository
 public interface SearchRecordRepository extends JpaRepository<SearchRecord, Long> {
     List<SearchRecord> findByUserIdOrderByCreatedAtDesc(Long userId);
     void deleteByUserId(Long userId);
+    long countByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/glancy/backend/service/SearchRecordService.java
+++ b/src/main/java/com/glancy/backend/service/SearchRecordService.java
@@ -11,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Service
 public class SearchRecordService {
@@ -27,6 +29,15 @@ public class SearchRecordService {
     public SearchRecordResponse saveRecord(Long userId, SearchRecordRequest request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("用户不存在"));
+        if (Boolean.FALSE.equals(user.getMember())) {
+            LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+            LocalDateTime endOfDay = startOfDay.plusDays(1);
+            long count = searchRecordRepository
+                    .countByUserIdAndCreatedAtBetween(userId, startOfDay, endOfDay);
+            if (count >= 10) {
+                throw new IllegalStateException("非会员每天只能搜索10次");
+            }
+        }
         SearchRecord record = new SearchRecord();
         record.setUser(user);
         record.setTerm(request.getTerm());


### PR DESCRIPTION
## Summary
- add `member` flag to `User`
- enforce daily limit in `SearchRecordService`
- expose userId in `WordController` and log searches
- extend `SearchRecordRepository` for date-range counts

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d54be63d48332ac53dfe14f2db0cd