### PR TITLE
Fix word search logic

### DIFF
--- a/src/main/java/com/glancy/backend/GlancyBackendApplication.java
+++ b/src/main/java/com/glancy/backend/GlancyBackendApplication.java
@@ -2,6 +2,8 @@ package com.glancy.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 public class GlancyBackendApplication {
@@ -9,5 +11,9 @@ public class GlancyBackendApplication {
         io.github.cdimascio.dotenv.Dotenv dotenv = io.github.cdimascio.dotenv.Dotenv.configure().load();
         System.setProperty("DB_PASSWORD", dotenv.get("DB_PASSWORD"));
         SpringApplication.run(GlancyBackendApplication.class, args);
+    }
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/src/main/java/com/glancy/backend/client/DeepSeekClient.java
+++ b/src/main/java/com/glancy/backend/client/DeepSeekClient.java
@@ -1,0 +1,29 @@
+package com.glancy.backend.client;
+
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class DeepSeekClient {
+    private final RestTemplate restTemplate;
+    private final String baseUrl;
+
+    public DeepSeekClient(RestTemplate restTemplate,
+                          @Value("${deepseek.base-url:https://api.deepseek.com}") String baseUrl) {
+        this.restTemplate = restTemplate;
+        this.baseUrl = baseUrl;
+    }
+
+    public WordResponse fetchDefinition(String term, Language language) {
+        String url = UriComponentsBuilder.fromHttpUrl(baseUrl)
+                .path("/words/definition")
+                .queryParam("term", term)
+                .queryParam("language", language.name().toLowerCase())
+                .toUriString();
+        return restTemplate.getForObject(url, WordResponse.class);
+    }
+}

--- a/src/main/java/com/glancy/backend/service/WordService.java
+++ b/src/main/java/com/glancy/backend/service/WordService.java
@@ -2,28 +2,20 @@ package com.glancy.backend.service;
 
 import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.Language;
-import com.glancy.backend.entity.Word;
-import com.glancy.backend.repository.WordRepository;
+import com.glancy.backend.client.DeepSeekClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class WordService {
-    private final WordRepository wordRepository;
+    private final DeepSeekClient deepSeekClient;
 
-    public WordService(WordRepository wordRepository) {
-        this.wordRepository = wordRepository;
+    public WordService(DeepSeekClient deepSeekClient) {
+        this.deepSeekClient = deepSeekClient;
     }
 
     @Transactional(readOnly = true)
     public WordResponse findWord(String term, Language language) {
-        Word word = wordRepository.findByTermAndLanguageAndDeletedFalse(term, language)
-                .orElseThrow(() -> new IllegalArgumentException("单词不存在"));
-        return toResponse(word);
-    }
-
-    private WordResponse toResponse(Word word) {
-        return new WordResponse(word.getId(), word.getTerm(), word.getDefinitions(),
-                word.getLanguage(), word.getExample());
+        return deepSeekClient.fetchDefinition(term, language);
     }
 }

--- a/src/test/java/com/glancy/backend/service/WordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/WordServiceTest.java
@@ -2,27 +2,27 @@ package com.glancy.backend.service;
 
 import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.Language;
-import com.glancy.backend.entity.Word;
-import com.glancy.backend.repository.WordRepository;
+import com.glancy.backend.client.DeepSeekClient;
 import io.github.cdimascio.dotenv.Dotenv;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @Transactional
 class WordServiceTest {
     @Autowired
     private WordService wordService;
-    @Autowired
-    private WordRepository wordRepository;
+    @MockBean
+    private DeepSeekClient deepSeekClient;
 
     @BeforeAll
     static void loadEnv() {
@@ -33,22 +33,15 @@ class WordServiceTest {
         }
     }
 
-    @BeforeEach
-    void setUp() {
-        wordRepository.deleteAll();
-    }
 
     @Test
     void testFindWord() {
-        Word w = new Word();
-        w.setTerm("hello");
-        w.setDefinitions(List.of("greeting"));
-        w.setLanguage(Language.ENGLISH);
-        w.setExample("Hello world");
-        Word saved = wordRepository.save(w);
+        WordResponse resp = new WordResponse(1L, "hello",
+                List.of("greeting"), Language.ENGLISH, "Hello world");
+        when(deepSeekClient.fetchDefinition("hello", Language.ENGLISH))
+                .thenReturn(resp);
 
-        WordResponse resp = wordService.findWord("hello", Language.ENGLISH);
-        assertEquals(saved.getId(), resp.getId());
-        assertEquals("greeting", resp.getDefinitions().get(0));
+        WordResponse result = wordService.findWord("hello", Language.ENGLISH);
+        assertEquals("greeting", result.getDefinitions().get(0));
     }
 }


### PR DESCRIPTION
## Summary
- add `DeepSeekClient` for online definitions
- inject `DeepSeekClient` into `WordService`
- expose `RestTemplate` bean
- update `WordServiceTest` to mock deepseek client

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d549f92b0833281c3a4f1fe7e6e76