### PR TITLE
Add global error logging

### DIFF
--- a/src/main/java/com/glancy/backend/dto/ErrorResponse.java
+++ b/src/main/java/com/glancy/backend/dto/ErrorResponse.java
@@ -1,0 +1,13 @@
+package com.glancy.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Simple error response body.
+ */
+@Data
+@AllArgsConstructor
+public class ErrorResponse {
+    private String message;
+}

--- a/src/main/java/com/glancy/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/glancy/backend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.glancy.backend.exception;
+
+import com.glancy.backend.dto.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Handles application exceptions and logs them.
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
+        log.error("Request resulted in error: {}", ex.getMessage(), ex);
+        return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+        log.error("Unhandled exception", ex);
+        return new ResponseEntity<>(new ErrorResponse("内部服务器错误"), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ErrorResponse` DTO for error payloads
- implement `GlobalExceptionHandler` using `@RestControllerAdvice` to log and return errors

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d591a68588332865da2a2b18f87f2