### PR TITLE
Add warn logs

### DIFF
--- a/src/main/java/com/glancy/backend/service/UserService.java
+++ b/src/main/java/com/glancy/backend/service/UserService.java
@@ -17,11 +17,13 @@ import com.glancy.backend.repository.LoginDeviceRepository;
 import com.glancy.backend.repository.ThirdPartyAccountRepository;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Provides core user management operations such as registration,
  * login and third-party account binding.
  */
+@Slf4j
 @Service
 public class UserService {
 
@@ -44,9 +46,11 @@ public class UserService {
     @Transactional
     public UserResponse register(UserRegistrationRequest req) {
         if (userRepository.findByUsernameAndDeletedFalse(req.getUsername()).isPresent()) {
+            log.warn("Username {} already exists", req.getUsername());
             throw new IllegalArgumentException("用户名已存在");
         }
         if (userRepository.findByEmailAndDeletedFalse(req.getEmail()).isPresent()) {
+            log.warn("Email {} is already in use", req.getEmail());
             throw new IllegalArgumentException("邮箱已被使用");
         }
         User user = new User();
@@ -89,15 +93,23 @@ public class UserService {
 
         if (req.getUsername() != null && !req.getUsername().isEmpty()) {
             user = userRepository.findByUsernameAndDeletedFalse(req.getUsername())
-                    .orElseThrow(() -> new IllegalArgumentException("用户不存在或已注销"));
+                    .orElseThrow(() -> {
+                        log.warn("User {} not found or deleted", req.getUsername());
+                        return new IllegalArgumentException("用户不存在或已注销");
+                    });
         } else if (req.getEmail() != null && !req.getEmail().isEmpty()) {
             user = userRepository.findByEmailAndDeletedFalse(req.getEmail())
-                    .orElseThrow(() -> new IllegalArgumentException("用户不存在或已注销"));
+                    .orElseThrow(() -> {
+                        log.warn("User with email {} not found or deleted", req.getEmail());
+                        return new IllegalArgumentException("用户不存在或已注销");
+                    });
         } else {
+            log.warn("Username or email must be provided for login");
             throw new IllegalArgumentException("用户名或邮箱必须填写其一");
         }
 
         if (!passwordEncoder.matches(req.getPassword(), user.getPassword())) {
+            log.warn("Password mismatch for user {}", user.getUsername());
             throw new IllegalArgumentException("密码错误");
         }
 
@@ -118,11 +130,15 @@ public class UserService {
     @Transactional
     public ThirdPartyAccountResponse bindThirdPartyAccount(Long userId, ThirdPartyAccountRequest req) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("用户不存在"));
+                .orElseThrow(() -> {
+                    log.warn("User with id {} not found", userId);
+                    return new IllegalArgumentException("用户不存在");
+                });
 
         thirdPartyAccountRepository
                 .findByProviderAndExternalId(req.getProvider(), req.getExternalId())
                 .ifPresent(a -> {
+                    log.warn("Third-party account {}:{} already bound", req.getProvider(), req.getExternalId());
                     throw new IllegalArgumentException("该第三方账号已绑定");
                 });
 


### PR DESCRIPTION
## Summary
- add `@Slf4j` to `UserService` and insert warning logs for duplicate username/email, login issues, and duplicate third-party bindings
- add `@Slf4j` to `SearchRecordService` and warn when users exceed daily search limits

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d591e276083328332d3de127aeb6d