### PR TITLE
Add i18n validation messages

### DIFF
--- a/src/main/java/com/glancy/backend/dto/ContactRequest.java
+++ b/src/main/java/com/glancy/backend/dto/ContactRequest.java
@@ -9,13 +9,13 @@ import lombok.Data;
  */
 @Data
 public class ContactRequest {
-    @NotBlank(message = "姓名不能为空")
+    @NotBlank(message = "{validation.contact.name.notblank}")
     private String name;
 
-    @NotBlank(message = "邮箱不能为空")
+    @NotBlank(message = "{validation.contact.email.notblank}")
     @Email(message = "邮箱格式不正确")
     private String email;
 
-    @NotBlank(message = "内容不能为空")
+    @NotBlank(message = "{validation.contact.message.notblank}")
     private String message;
 }

--- a/src/main/java/com/glancy/backend/dto/FaqRequest.java
+++ b/src/main/java/com/glancy/backend/dto/FaqRequest.java
@@ -8,9 +8,9 @@ import lombok.Data;
  */
 @Data
 public class FaqRequest {
-    @NotBlank(message = "问题不能为空")
+    @NotBlank(message = "{validation.faq.question.notblank}")
     private String question;
 
-    @NotBlank(message = "答案不能为空")
+    @NotBlank(message = "{validation.faq.answer.notblank}")
     private String answer;
 }

--- a/src/main/java/com/glancy/backend/dto/LoginRequest.java
+++ b/src/main/java/com/glancy/backend/dto/LoginRequest.java
@@ -11,7 +11,6 @@ public class LoginRequest {
     private String username;  // 可选
     private String email;     // 可选
 
-    @NotBlank(message = "密码不能为空")
+    @NotBlank(message = "{validation.login.password.notblank}")
     private String password;
-
     // Optional device information used during login    private String deviceInfo;}

--- a/src/main/java/com/glancy/backend/dto/NotificationRequest.java
+++ b/src/main/java/com/glancy/backend/dto/NotificationRequest.java
@@ -8,6 +8,6 @@ import lombok.Data;
  */
 @Data
 public class NotificationRequest {
-    @NotBlank(message = "通知内容不能为空")
+    @NotBlank(message = "{validation.notification.message.notblank}")
     private String message;
 }

--- a/src/main/java/com/glancy/backend/dto/SearchRecordRequest.java
+++ b/src/main/java/com/glancy/backend/dto/SearchRecordRequest.java
@@ -10,7 +10,7 @@ import lombok.Data;
  */
 @Data
 public class SearchRecordRequest {
-    @NotBlank(message = "搜索词不能为空")
+    @NotBlank(message = "{validation.searchRecord.term.notblank}")
     private String term;
 
     @NotNull(message = "语言不能为空")

--- a/src/main/java/com/glancy/backend/dto/ThirdPartyAccountRequest.java
+++ b/src/main/java/com/glancy/backend/dto/ThirdPartyAccountRequest.java
@@ -8,9 +8,9 @@ import lombok.Data;
  */
 @Data
 public class ThirdPartyAccountRequest {
-    @NotBlank(message = "平台不能为空")
+    @NotBlank(message = "{validation.thirdPartyAccount.provider.notblank}")
     private String provider;
 
-    @NotBlank(message = "外部ID不能为空")
+    @NotBlank(message = "{validation.thirdPartyAccount.externalId.notblank}")
     private String externalId;
 }

--- a/src/main/java/com/glancy/backend/dto/UserPreferenceRequest.java
+++ b/src/main/java/com/glancy/backend/dto/UserPreferenceRequest.java
@@ -8,10 +8,10 @@ import lombok.Data;
  */
 @Data
 public class UserPreferenceRequest {
-    @NotBlank
+    @NotBlank(message = "{validation.userPreference.theme.notblank}")
     private String theme;
-    @NotBlank
+    @NotBlank(message = "{validation.userPreference.systemLanguage.notblank}")
     private String systemLanguage;
-    @NotBlank
+    @NotBlank(message = "{validation.userPreference.searchLanguage.notblank}")
     private String searchLanguage;
 }

--- a/src/main/java/com/glancy/backend/dto/UserRegistrationRequest.java
+++ b/src/main/java/com/glancy/backend/dto/UserRegistrationRequest.java
@@ -8,19 +8,18 @@ import lombok.Data;
  */
 @Data
 public class UserRegistrationRequest {
-    @NotBlank(message = "用户名不能为空")
+    @NotBlank(message = "{validation.userRegistration.username.notblank}")
     @Size(min = 3, max = 50, message = "用户名长度需在3到50之间")
     private String username;
 
-    @NotBlank(message = "密码不能为空")
+    @NotBlank(message = "{validation.userRegistration.password.notblank}")
     @Size(min = 6, message = "密码长度至少为6位")
     private String password;
 
-    @NotBlank(message = "邮箱不能为空")
+    @NotBlank(message = "{validation.userRegistration.email.notblank}")
     @Email(message = "邮箱格式不正确")
     private String email;
 
     // Optional avatar URL
     private String avatar;
-
     // Optional phone number    private String phone;}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: glancy
+  messages:
+    basename: messages
   datasource:
     url: jdbc:mysql://localhost:3306/glancy_db?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=Asia/Shanghai&characterEncoding=utf8
     username: glancy_user
@@ -19,5 +21,4 @@ spring:
 management:
   endpoints:
     web:
-      exposure:
-        include: health,info
+      exposure:        include: health,info

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,16 @@
+validation.contact.name.notblank=Name must not be blank
+validation.contact.email.notblank=Email must not be blank
+validation.contact.message.notblank=Message must not be blank
+validation.faq.question.notblank=Question must not be blank
+validation.faq.answer.notblank=Answer must not be blank
+validation.login.password.notblank=Password must not be blank
+validation.notification.message.notblank=Notification message must not be blank
+validation.searchRecord.term.notblank=Search term must not be blank
+validation.thirdPartyAccount.provider.notblank=Provider must not be blank
+validation.thirdPartyAccount.externalId.notblank=External ID must not be blank
+validation.userPreference.theme.notblank=Theme must not be blank
+validation.userPreference.systemLanguage.notblank=System language must not be blank
+validation.userPreference.searchLanguage.notblank=Search language must not be blank
+validation.userRegistration.username.notblank=Username must not be blank
+validation.userRegistration.password.notblank=Password must not be blank
+validation.userRegistration.email.notblank=Email must not be blank

--- a/src/main/resources/messages_zh.properties
+++ b/src/main/resources/messages_zh.properties
@@ -1,0 +1,16 @@
+validation.contact.name.notblank=姓名不能为空
+validation.contact.email.notblank=邮箱不能为空
+validation.contact.message.notblank=内容不能为空
+validation.faq.question.notblank=问题不能为空
+validation.faq.answer.notblank=答案不能为空
+validation.login.password.notblank=密码不能为空
+validation.notification.message.notblank=通知内容不能为空
+validation.searchRecord.term.notblank=搜索词不能为空
+validation.thirdPartyAccount.provider.notblank=平台不能为空
+validation.thirdPartyAccount.externalId.notblank=外部ID不能为空
+validation.userPreference.theme.notblank=主题不能为空
+validation.userPreference.systemLanguage.notblank=系统语言不能为空
+validation.userPreference.searchLanguage.notblank=搜索语言不能为空
+validation.userRegistration.username.notblank=用户名不能为空
+validation.userRegistration.password.notblank=密码不能为空
+validation.userRegistration.email.notblank=邮箱不能为空


### PR DESCRIPTION
## Summary
- support internationalized validation messages
- provide message properties in English and Chinese
- update DTO `@NotBlank` annotations to reference message keys
- configure Spring messages basename in `application.yml`

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d59d934448332957eefa562a59eca