### PR TITLE
Add i18n support for validation messages

### DIFF
--- a/src/main/java/com/glancy/backend/dto/SearchRecordRequest.java
+++ b/src/main/java/com/glancy/backend/dto/SearchRecordRequest.java
@@ -13,6 +13,6 @@ public class SearchRecordRequest {
     @NotBlank(message = "{validation.searchRecord.term.notblank}")
     private String term;
 
-    @NotNull(message = "语言不能为空")
+    @NotNull(message = "{validation.searchRecord.language.notnull}")
     private Language language;
 }

--- a/src/main/java/com/glancy/backend/dto/SystemParameterRequest.java
+++ b/src/main/java/com/glancy/backend/dto/SystemParameterRequest.java
@@ -8,9 +8,9 @@ import lombok.Data;
  */
 @Data
 public class SystemParameterRequest {
-    @NotBlank(message = "参数名不能为空")
+    @NotBlank(message = "{validation.systemParameter.name.notblank}")
     private String name;
 
-    @NotBlank(message = "参数值不能为空")
+    @NotBlank(message = "{validation.systemParameter.value.notblank}")
     private String value;
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -14,3 +14,6 @@ validation.userPreference.searchLanguage.notblank=Search language must not be bl
 validation.userRegistration.username.notblank=Username must not be blank
 validation.userRegistration.password.notblank=Password must not be blank
 validation.userRegistration.email.notblank=Email must not be blank
+validation.searchRecord.language.notnull=Language must not be null
+validation.systemParameter.name.notblank=Parameter name must not be blank
+validation.systemParameter.value.notblank=Parameter value must not be blank

--- a/src/main/resources/messages_zh.properties
+++ b/src/main/resources/messages_zh.properties
@@ -14,3 +14,6 @@ validation.userPreference.searchLanguage.notblank=搜索语言不能为空
 validation.userRegistration.username.notblank=用户名不能为空
 validation.userRegistration.password.notblank=密码不能为空
 validation.userRegistration.email.notblank=邮箱不能为空
+validation.searchRecord.language.notnull=语言不能为空
+validation.systemParameter.name.notblank=参数名不能为空
+validation.systemParameter.value.notblank=参数值不能为空


### PR DESCRIPTION
## Summary
- localize `@NotNull` language message in `SearchRecordRequest`
- localize `SystemParameterRequest` validation messages
- add English and Chinese text for new keys

## Testing
- `./mvnw test -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d5c50ce50833292c8b7e3d36e8a40