### PR TITLE
Add avatar retrieval and update

### DIFF
--- a/src/main/java/com/glancy/backend/controller/UserController.java
+++ b/src/main/java/com/glancy/backend/controller/UserController.java
@@ -11,6 +11,8 @@ import com.glancy.backend.dto.UserRegistrationRequest;
 import com.glancy.backend.dto.UserResponse;
 import com.glancy.backend.dto.ThirdPartyAccountRequest;
 import com.glancy.backend.dto.ThirdPartyAccountResponse;
+import com.glancy.backend.dto.AvatarRequest;
+import com.glancy.backend.dto.AvatarResponse;
 import com.glancy.backend.entity.User;
 import com.glancy.backend.service.UserService;
 
@@ -68,8 +70,30 @@ public class UserController {
      * Bind a third-party account to the specified user.
      */
     @PostMapping("/{id}/third-party-accounts")
-    public ResponseEntity<ThirdPartyAccountResponse> bindThirdParty(@PathVariable Long id,
-                                               @Valid @RequestBody ThirdPartyAccountRequest req) {        ThirdPartyAccountResponse resp = userService.bindThirdPartyAccount(id, req);
+    public ResponseEntity<ThirdPartyAccountResponse> bindThirdParty(
+            @PathVariable Long id,
+            @Valid @RequestBody ThirdPartyAccountRequest req) {
+        ThirdPartyAccountResponse resp = userService.bindThirdPartyAccount(id, req);
         return new ResponseEntity<>(resp, HttpStatus.CREATED);
+    }
+
+    /**
+     * Get the avatar URL for a specific user.
+     */
+    @GetMapping("/{id}/avatar")
+    public ResponseEntity<AvatarResponse> getAvatar(@PathVariable Long id) {
+        AvatarResponse resp = userService.getAvatar(id);
+        return ResponseEntity.ok(resp);
+    }
+
+    /**
+     * Update the avatar URL for a user.
+     */
+    @PutMapping("/{id}/avatar")
+    public ResponseEntity<AvatarResponse> updateAvatar(
+            @PathVariable Long id,
+            @Valid @RequestBody AvatarRequest req) {
+        AvatarResponse resp = userService.updateAvatar(id, req.getAvatar());
+        return ResponseEntity.ok(resp);
     }
 }

--- a/src/main/java/com/glancy/backend/dto/AvatarRequest.java
+++ b/src/main/java/com/glancy/backend/dto/AvatarRequest.java
@@ -1,0 +1,13 @@
+package com.glancy.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+/**
+ * Request body used when updating a user's avatar.
+ */
+@Data
+public class AvatarRequest {
+    @NotBlank(message = "头像地址不能为空")
+    private String avatar;
+}

--- a/src/main/java/com/glancy/backend/dto/AvatarResponse.java
+++ b/src/main/java/com/glancy/backend/dto/AvatarResponse.java
@@ -1,0 +1,13 @@
+package com.glancy.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Returned when querying or updating a user's avatar.
+ */
+@Data
+@AllArgsConstructor
+public class AvatarResponse {
+    private String avatar;
+}

--- a/src/main/java/com/glancy/backend/service/UserService.java
+++ b/src/main/java/com/glancy/backend/service/UserService.java
@@ -10,6 +10,7 @@ import com.glancy.backend.dto.UserRegistrationRequest;
 import com.glancy.backend.dto.UserResponse;
 import com.glancy.backend.dto.ThirdPartyAccountRequest;
 import com.glancy.backend.dto.ThirdPartyAccountResponse;
+import com.glancy.backend.dto.AvatarResponse;
 import com.glancy.backend.entity.User;
 import com.glancy.backend.entity.LoginDevice;
 import com.glancy.backend.entity.ThirdPartyAccount;
@@ -173,5 +174,29 @@ public class UserService {
         log.debug("Bound account {}:{} to user {}", saved.getProvider(), saved.getExternalId(), userId);
         return new ThirdPartyAccountResponse(saved.getId(), saved.getProvider(),
                 saved.getExternalId(), saved.getUser().getId());
+    }
+
+    /**
+     * Retrieve only the avatar URL of a user.
+     */
+    @Transactional(readOnly = true)
+    public AvatarResponse getAvatar(Long userId) {
+        log.info("Fetching avatar for user {}", userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("用户不存在"));
+        return new AvatarResponse(user.getAvatar());
+    }
+
+    /**
+     * Update the avatar URL for the specified user.
+     */
+    @Transactional
+    public AvatarResponse updateAvatar(Long userId, String avatar) {
+        log.info("Updating avatar for user {}", userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("用户不存在"));
+        user.setAvatar(avatar);
+        User saved = userRepository.save(user);
+        return new AvatarResponse(saved.getAvatar());
     }
 }

--- a/src/test/java/com/glancy/backend/controller/UserControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/UserControllerTest.java
@@ -98,4 +98,30 @@ class UserControllerTest {
                         .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(1L));
-    }}
+    }
+
+    @Test
+    void getAvatar() throws Exception {
+        AvatarResponse resp = new AvatarResponse("url");
+        when(userService.getAvatar(1L)).thenReturn(resp);
+
+        mockMvc.perform(get("/api/users/1/avatar"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.avatar").value("url"));
+    }
+
+    @Test
+    void updateAvatar() throws Exception {
+        AvatarResponse resp = new AvatarResponse("url");
+        when(userService.updateAvatar(eq(1L), eq("url"))).thenReturn(resp);
+
+        AvatarRequest req = new AvatarRequest();
+        req.setAvatar("url");
+
+        mockMvc.perform(put("/api/users/1/avatar")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.avatar").value("url"));
+    }
+}

--- a/src/test/java/com/glancy/backend/service/UserServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/UserServiceTest.java
@@ -3,6 +3,7 @@ package com.glancy.backend.service;
 import com.glancy.backend.dto.UserRegistrationRequest;
 import com.glancy.backend.dto.UserResponse;
 import com.glancy.backend.dto.LoginRequest;
+import com.glancy.backend.dto.AvatarResponse;
 import com.glancy.backend.entity.User;
 import com.glancy.backend.entity.LoginDevice;
 import com.glancy.backend.repository.UserRepository;
@@ -141,5 +142,20 @@ class UserServiceTest {
         List<LoginDevice> devices = loginDeviceRepository
                 .findByUserIdOrderByLoginTimeAsc(resp.getId());
         assertEquals(3, devices.size());
-        assertFalse(devices.stream().anyMatch(d -> "d1".equals(d.getDeviceInfo())));
-    }}
+        assertFalse(devices.stream().anyMatch(d -> "d1".equals(d.getDeviceInfo())));    }
+
+    @Test
+    void testUpdateAvatar() {
+        UserRegistrationRequest req = new UserRegistrationRequest();
+        req.setUsername("avataruser");
+        req.setPassword("pass123");
+        req.setEmail("avatar@example.com");
+        UserResponse resp = userService.register(req);
+
+        AvatarResponse updated = userService.updateAvatar(resp.getId(), "url");
+        assertEquals("url", updated.getAvatar());
+
+        AvatarResponse fetched = userService.getAvatar(resp.getId());
+        assertEquals("url", fetched.getAvatar());
+    }
+}


### PR DESCRIPTION
## Summary
- add DTOs for avatar updates
- implement avatar get/update service methods and endpoints
- test avatar endpoints and service logic

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d64e4db2883329ed42d397a901438