### PR TITLE
Add portal traffic monitoring

### DIFF
--- a/src/main/java/com/glancy/backend/controller/PortalTrafficController.java
+++ b/src/main/java/com/glancy/backend/controller/PortalTrafficController.java
@@ -1,0 +1,47 @@
+package com.glancy.backend.controller;
+
+import com.glancy.backend.dto.TrafficRecordRequest;
+import com.glancy.backend.dto.TrafficRecordResponse;
+import com.glancy.backend.service.TrafficRecordService;
+import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Endpoints for portal traffic monitoring.
+ */
+@RestController
+@RequestMapping("/api/portal/traffic")
+public class PortalTrafficController {
+
+    private final TrafficRecordService trafficRecordService;
+
+    public PortalTrafficController(TrafficRecordService trafficRecordService) {
+        this.trafficRecordService = trafficRecordService;
+    }
+
+    /**
+     * Record a portal visit.
+     */
+    @PostMapping
+    public ResponseEntity<TrafficRecordResponse> record(@Valid @RequestBody TrafficRecordRequest req) {
+        TrafficRecordResponse resp = trafficRecordService.record(req);
+        return new ResponseEntity<>(resp, HttpStatus.CREATED);
+    }
+
+    /**
+     * Get daily visit counts between two dates.
+     */
+    @GetMapping("/daily")
+    public ResponseEntity<List<Long>> daily(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end) {
+        List<Long> counts = trafficRecordService.countDaily(start, end);
+        return ResponseEntity.ok(counts);
+    }
+}

--- a/src/main/java/com/glancy/backend/dto/TrafficRecordRequest.java
+++ b/src/main/java/com/glancy/backend/dto/TrafficRecordRequest.java
@@ -1,0 +1,15 @@
+package com.glancy.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+/**
+ * Request object for logging portal traffic.
+ */
+@Data
+public class TrafficRecordRequest {
+    @NotBlank(message = "{validation.traffic.path.notblank}")
+    private String path;
+    private String ip;
+    private String userAgent;
+}

--- a/src/main/java/com/glancy/backend/dto/TrafficRecordResponse.java
+++ b/src/main/java/com/glancy/backend/dto/TrafficRecordResponse.java
@@ -1,0 +1,19 @@
+package com.glancy.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * Response representing a stored traffic record.
+ */
+@Data
+@AllArgsConstructor
+public class TrafficRecordResponse {
+    private Long id;
+    private String path;
+    private String ip;
+    private String userAgent;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/glancy/backend/entity/TrafficRecord.java
+++ b/src/main/java/com/glancy/backend/entity/TrafficRecord.java
@@ -1,0 +1,32 @@
+package com.glancy.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Records each portal visit for traffic monitoring.
+ */
+@Entity
+@Table(name = "traffic_records")
+@Data
+@NoArgsConstructor
+public class TrafficRecord {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String path;
+
+    @Column(length = 45)
+    private String ip;
+
+    @Column(length = 255)
+    private String userAgent;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/src/main/java/com/glancy/backend/repository/TrafficRecordRepository.java
+++ b/src/main/java/com/glancy/backend/repository/TrafficRecordRepository.java
@@ -1,0 +1,15 @@
+package com.glancy.backend.repository;
+
+import com.glancy.backend.entity.TrafficRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+/**
+ * Repository for portal traffic records.
+ */
+@Repository
+public interface TrafficRecordRepository extends JpaRepository<TrafficRecord, Long> {
+    long countByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/com/glancy/backend/service/TrafficRecordService.java
+++ b/src/main/java/com/glancy/backend/service/TrafficRecordService.java
@@ -1,0 +1,68 @@
+package com.glancy.backend.service;
+
+import com.glancy.backend.dto.TrafficRecordRequest;
+import com.glancy.backend.dto.TrafficRecordResponse;
+import com.glancy.backend.entity.TrafficRecord;
+import com.glancy.backend.repository.TrafficRecordRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Provides methods to log and retrieve portal traffic information.
+ */
+@Service
+public class TrafficRecordService {
+    private final TrafficRecordRepository trafficRecordRepository;
+
+    public TrafficRecordService(TrafficRecordRepository trafficRecordRepository) {
+        this.trafficRecordRepository = trafficRecordRepository;
+    }
+
+    /**
+     * Save a traffic record when the portal is visited.
+     */
+    @Transactional
+    public TrafficRecordResponse record(TrafficRecordRequest request) {
+        TrafficRecord record = new TrafficRecord();
+        record.setPath(request.getPath());
+        record.setIp(request.getIp());
+        record.setUserAgent(request.getUserAgent());
+        TrafficRecord saved = trafficRecordRepository.save(record);
+        return toResponse(saved);
+    }
+
+    /**
+     * Count visits between the provided dates (inclusive).
+     */
+    @Transactional(readOnly = true)
+    public long count(LocalDate start, LocalDate end) {
+        LocalDateTime s = start.atStartOfDay();
+        LocalDateTime e = end.plusDays(1).atStartOfDay();
+        return trafficRecordRepository.countByCreatedAtBetween(s, e);
+    }
+
+    /**
+     * Retrieve daily counts for a date range.
+     */
+    @Transactional(readOnly = true)
+    public List<Long> countDaily(LocalDate start, LocalDate end) {
+        List<Long> result = new ArrayList<>();
+        LocalDate cursor = start;
+        while (!cursor.isAfter(end)) {
+            long c = count(cursor, cursor);
+            result.add(c);
+            cursor = cursor.plusDays(1);
+        }
+        return result;
+    }
+
+    private TrafficRecordResponse toResponse(TrafficRecord record) {
+        return new TrafficRecordResponse(record.getId(), record.getPath(),
+                record.getIp(), record.getUserAgent(), record.getCreatedAt());
+    }
+}

--- a/src/test/java/com/glancy/backend/controller/PortalTrafficControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/PortalTrafficControllerTest.java
@@ -1,0 +1,67 @@
+package com.glancy.backend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.glancy.backend.dto.TrafficRecordRequest;
+import com.glancy.backend.dto.TrafficRecordResponse;
+import com.glancy.backend.service.TrafficRecordService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(PortalTrafficController.class)
+class PortalTrafficControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TrafficRecordService trafficRecordService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void recordTraffic() throws Exception {
+        TrafficRecordResponse resp = new TrafficRecordResponse(1L, "/", "ip",
+                "ua", LocalDateTime.now());
+        when(trafficRecordService.record(any(TrafficRecordRequest.class)))
+                .thenReturn(resp);
+
+        TrafficRecordRequest req = new TrafficRecordRequest();
+        req.setPath("/");
+        req.setIp("ip");
+        req.setUserAgent("ua");
+
+        mockMvc.perform(post("/api/portal/traffic")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1L));
+    }
+
+    @Test
+    void dailyCounts() throws Exception {
+        when(trafficRecordService.countDaily(LocalDate.parse("2024-01-01"),
+                LocalDate.parse("2024-01-02")))
+                .thenReturn(List.of(5L, 3L));
+
+        mockMvc.perform(get("/api/portal/traffic/daily")
+                        .param("start", "2024-01-01")
+                        .param("end", "2024-01-02"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0]").value(5))
+                .andExpect(jsonPath("$[1]").value(3));
+    }
+}

--- a/src/test/java/com/glancy/backend/service/TrafficRecordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/TrafficRecordServiceTest.java
@@ -1,0 +1,56 @@
+package com.glancy.backend.service;
+
+import com.glancy.backend.dto.TrafficRecordRequest;
+import com.glancy.backend.dto.TrafficRecordResponse;
+import com.glancy.backend.repository.TrafficRecordRepository;
+import io.github.cdimascio.dotenv.Dotenv;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class TrafficRecordServiceTest {
+
+    @Autowired
+    private TrafficRecordService trafficRecordService;
+    @Autowired
+    private TrafficRecordRepository trafficRecordRepository;
+
+    @BeforeAll
+    static void loadEnv() {
+        Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+        String dbPassword = dotenv.get("DB_PASSWORD");
+        if (dbPassword != null) {
+            System.setProperty("DB_PASSWORD", dbPassword);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        trafficRecordRepository.deleteAll();
+    }
+
+    @Test
+    void recordAndCount() {
+        TrafficRecordRequest req = new TrafficRecordRequest();
+        req.setPath("/");
+        TrafficRecordResponse resp = trafficRecordService.record(req);
+        assertNotNull(resp.getId());
+
+        long count = trafficRecordService.count(LocalDate.now(), LocalDate.now());
+        assertEquals(1, count);
+
+        List<Long> daily = trafficRecordService.countDaily(LocalDate.now(), LocalDate.now());
+        assertEquals(1, daily.size());
+        assertEquals(1L, daily.get(0));
+    }
+}


### PR DESCRIPTION
## Summary
- implement a portal traffic feature
- add traffic record entity, repository, DTOs, service and controller
- provide daily traffic stats endpoint
- cover new service and controller with tests

## Testing
- `./mvnw test -q` *(fails: Network is unreachable while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d64896d1483329b3da6c83cfd6a2a