### PR TITLE
Add runtime log level adjustment

### DIFF
--- a/src/main/java/com/glancy/backend/controller/PortalController.java
+++ b/src/main/java/com/glancy/backend/controller/PortalController.java
@@ -9,7 +9,9 @@ import org.springframework.web.bind.annotation.*;
 
 import com.glancy.backend.dto.SystemParameterRequest;
 import com.glancy.backend.dto.SystemParameterResponse;
+import com.glancy.backend.dto.LogLevelRequest;
 import com.glancy.backend.service.SystemParameterService;
+import com.glancy.backend.service.LoggingService;
 
 /**
  * Portal endpoints used by administrators to adjust runtime
@@ -20,9 +22,12 @@ import com.glancy.backend.service.SystemParameterService;
 public class PortalController {
 
     private final SystemParameterService parameterService;
+    private final LoggingService loggingService;
 
-    public PortalController(SystemParameterService parameterService) {
+    public PortalController(SystemParameterService parameterService,
+            LoggingService loggingService) {
         this.parameterService = parameterService;
+        this.loggingService = loggingService;
     }
 
     /**
@@ -51,5 +56,15 @@ public class PortalController {
     public ResponseEntity<List<SystemParameterResponse>> list() {
         List<SystemParameterResponse> resp = parameterService.list();
         return ResponseEntity.ok(resp);
+    }
+
+    /**
+     * Change the log level for a given logger.
+     */
+    @PostMapping("/log-level")
+    public ResponseEntity<Void> setLogLevel(
+            @Valid @RequestBody LogLevelRequest req) {
+        loggingService.setLogLevel(req.getLogger(), req.getLevel());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/glancy/backend/dto/LogLevelRequest.java
+++ b/src/main/java/com/glancy/backend/dto/LogLevelRequest.java
@@ -1,0 +1,16 @@
+package com.glancy.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+/**
+ * Request body for changing the log level of a logger at runtime.
+ */
+@Data
+public class LogLevelRequest {
+    @NotBlank(message = "{validation.logLevel.logger.notblank}")
+    private String logger;
+
+    @NotBlank(message = "{validation.logLevel.level.notblank}")
+    private String level;
+}

--- a/src/main/java/com/glancy/backend/service/LoggingService.java
+++ b/src/main/java/com/glancy/backend/service/LoggingService.java
@@ -1,0 +1,28 @@
+package com.glancy.backend.service;
+
+import org.springframework.boot.logging.LogLevel;
+import org.springframework.boot.logging.LoggingSystem;
+import org.springframework.stereotype.Service;
+
+/**
+ * Allows changing the application's log level at runtime.
+ */
+@Service
+public class LoggingService {
+    private final LoggingSystem loggingSystem;
+
+    public LoggingService(LoggingSystem loggingSystem) {
+        this.loggingSystem = loggingSystem;
+    }
+
+    /**
+     * Update the log level for the given logger name.
+     *
+     * @param loggerName the logger to update (e.g. "com.glancy.backend")
+     * @param level the desired log level (e.g. "DEBUG")
+     */
+    public void setLogLevel(String loggerName, String level) {
+        LogLevel target = LogLevel.valueOf(level.toUpperCase());
+        loggingSystem.setLogLevel(loggerName, target);
+    }
+}


### PR DESCRIPTION
## Summary
- add `LogLevelRequest` DTO
- implement `LoggingService` to update logging level through `LoggingSystem`
- extend `PortalController` with `/api/portal/log-level` endpoint

## Testing
- `./mvnw test -q` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d646d84c48332906654ff48625b66