### PR TITLE
新增会员延期接口

### DIFF
--- a/src/main/java/com/glancy/backend/controller/PortalController.java
+++ b/src/main/java/com/glancy/backend/controller/PortalController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.*;
 import com.glancy.backend.dto.SystemParameterRequest;
 import com.glancy.backend.dto.SystemParameterResponse;
 import com.glancy.backend.service.SystemParameterService;
+import com.glancy.backend.service.UserService;
+import com.glancy.backend.entity.User;
 
 /**
  * Portal endpoints used by administrators to adjust runtime
@@ -20,9 +22,11 @@ import com.glancy.backend.service.SystemParameterService;
 public class PortalController {
 
     private final SystemParameterService parameterService;
+    private final UserService userService;
 
-    public PortalController(SystemParameterService parameterService) {
+    public PortalController(SystemParameterService parameterService, UserService userService) {
         this.parameterService = parameterService;
+        this.userService = userService;
     }
 
     /**
@@ -51,5 +55,15 @@ public class PortalController {
     public ResponseEntity<List<SystemParameterResponse>> list() {
         List<SystemParameterResponse> resp = parameterService.list();
         return ResponseEntity.ok(resp);
+    }
+
+    /**
+     * Extend membership for specified user.
+     */
+    @PostMapping("/users/{id}/extend-membership")
+    public ResponseEntity<User> extendMembership(@PathVariable Long id,
+                                                 @RequestParam(defaultValue = "30") int days) {
+        User user = userService.extendMembership(id, days);
+        return ResponseEntity.ok(user);
     }
 }

--- a/src/main/java/com/glancy/backend/entity/User.java
+++ b/src/main/java/com/glancy/backend/entity/User.java
@@ -3,6 +3,7 @@ package com.glancy.backend.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 /**
  * Core user entity storing login credentials and profile info.
@@ -34,7 +35,11 @@ public class User {
     @Column(nullable = false)
     private Boolean deleted = false;
 
-    @Column(nullable = false)    private Boolean member = false;
+    @Column(nullable = false)
+    private Boolean member = false;
+
+    private LocalDate membershipExpiresAt;
 
     @Column(nullable = false)
-    private LocalDateTime createdAt = LocalDateTime.now();}
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/src/main/java/com/glancy/backend/service/SearchRecordService.java
+++ b/src/main/java/com/glancy/backend/service/SearchRecordService.java
@@ -44,7 +44,10 @@ public class SearchRecordService {
                     log.warn("User with id {} not found", userId);
                     return new IllegalArgumentException("用户不存在");
                 });
-        if (Boolean.FALSE.equals(user.getMember())) {
+        boolean activeMember = Boolean.TRUE.equals(user.getMember())
+                || (user.getMembershipExpiresAt() != null
+                    && user.getMembershipExpiresAt().isAfter(LocalDate.now()));
+        if (!activeMember) {
             LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
             LocalDateTime endOfDay = startOfDay.plusDays(1);
             long count = searchRecordRepository

--- a/src/test/java/com/glancy/backend/service/UserServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/UserServiceTest.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
+import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -141,5 +142,19 @@ class UserServiceTest {
         List<LoginDevice> devices = loginDeviceRepository
                 .findByUserIdOrderByLoginTimeAsc(resp.getId());
         assertEquals(3, devices.size());
-        assertFalse(devices.stream().anyMatch(d -> "d1".equals(d.getDeviceInfo())));
-    }}
+        assertFalse(devices.stream().anyMatch(d -> "d1".equals(d.getDeviceInfo())));    }
+
+    @Test
+    void testExtendMembership() {
+        UserRegistrationRequest req = new UserRegistrationRequest();
+        req.setUsername("memberuser");
+        req.setPassword("pass123");
+        req.setEmail("m@example.com");
+        UserResponse resp = userService.register(req);
+
+        User user = userService.extendMembership(resp.getId(), 10);
+        assertNotNull(user.getMembershipExpiresAt());
+        assertTrue(user.getMembershipExpiresAt().isAfter(LocalDate.now()));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `membershipExpiresAt` field to `User`
- update search record service to check membership expiry
- allow extending membership in `UserService`
- expose portal endpoint to extend membership for a user
- test extending membership

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d65dba31c8332bc38e355353b4bf9