### PR TITLE
新增Portal会员开通接口

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,5 @@ java -jar target/glancy-backend-0.0.1-SNAPSHOT.jar
 - `POST /api/portal/parameters` – create or update a runtime parameter
 - `GET /api/portal/parameters/{name}` – get the value of a parameter
 - `GET /api/portal/parameters` – list all parameters
+- `POST /api/portal/users/{userId}/membership` – enable membership for a user
 

--- a/src/main/java/com/glancy/backend/controller/PortalController.java
+++ b/src/main/java/com/glancy/backend/controller/PortalController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.*;
 import com.glancy.backend.dto.SystemParameterRequest;
 import com.glancy.backend.dto.SystemParameterResponse;
 import com.glancy.backend.service.SystemParameterService;
+import com.glancy.backend.service.UserService;
+import com.glancy.backend.dto.UserResponse;
 
 /**
  * Portal endpoints used by administrators to adjust runtime
@@ -20,9 +22,11 @@ import com.glancy.backend.service.SystemParameterService;
 public class PortalController {
 
     private final SystemParameterService parameterService;
+    private final UserService userService;
 
-    public PortalController(SystemParameterService parameterService) {
+    public PortalController(SystemParameterService parameterService, UserService userService) {
         this.parameterService = parameterService;
+        this.userService = userService;
     }
 
     /**
@@ -50,6 +54,15 @@ public class PortalController {
     @GetMapping("/parameters")
     public ResponseEntity<List<SystemParameterResponse>> list() {
         List<SystemParameterResponse> resp = parameterService.list();
+        return ResponseEntity.ok(resp);
+    }
+
+    /**
+     * Enable membership for a user.
+     */
+    @PostMapping("/users/{userId}/membership")
+    public ResponseEntity<UserResponse> enableMembership(@PathVariable Long userId) {
+        UserResponse resp = userService.enableMembership(userId);
         return ResponseEntity.ok(resp);
     }
 }

--- a/src/main/java/com/glancy/backend/service/UserService.java
+++ b/src/main/java/com/glancy/backend/service/UserService.java
@@ -174,4 +174,19 @@ public class UserService {
         return new ThirdPartyAccountResponse(saved.getId(), saved.getProvider(),
                 saved.getExternalId(), saved.getUser().getId());
     }
+
+    /**
+     * Enable membership status for the specified user.
+     */
+    @Transactional
+    public UserResponse enableMembership(Long userId) {
+        log.info("Enabling membership for user {}", userId);
+        log.debug("Enabling membership for user {}", userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("用户不存在"));
+        user.setMember(true);
+        User saved = userRepository.save(user);
+        return new UserResponse(saved.getId(), saved.getUsername(), saved.getEmail(),
+                saved.getAvatar(), saved.getPhone());
+    }
 }

--- a/src/test/java/com/glancy/backend/controller/PortalControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/PortalControllerTest.java
@@ -1,0 +1,38 @@
+package com.glancy.backend.controller;
+
+import com.glancy.backend.dto.UserResponse;
+import com.glancy.backend.service.SystemParameterService;
+import com.glancy.backend.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(PortalController.class)
+class PortalControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SystemParameterService parameterService;
+
+    @MockBean
+    private UserService userService;
+
+
+    @Test
+    void enableMembership() throws Exception {
+        UserResponse resp = new UserResponse(1L, "u", "e", null, null);
+        when(userService.enableMembership(1L)).thenReturn(resp);
+
+        mockMvc.perform(post("/api/portal/users/1/membership"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L));
+    }
+}

--- a/src/test/java/com/glancy/backend/service/UserServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/UserServiceTest.java
@@ -141,5 +141,18 @@ class UserServiceTest {
         List<LoginDevice> devices = loginDeviceRepository
                 .findByUserIdOrderByLoginTimeAsc(resp.getId());
         assertEquals(3, devices.size());
-        assertFalse(devices.stream().anyMatch(d -> "d1".equals(d.getDeviceInfo())));
-    }}
+        assertFalse(devices.stream().anyMatch(d -> "d1".equals(d.getDeviceInfo())));    }
+
+    @Test
+    void testEnableMembership() {
+        UserRegistrationRequest req = new UserRegistrationRequest();
+        req.setUsername("memberuser");
+        req.setPassword("pass123");
+        req.setEmail("member@example.com");
+        UserResponse resp = userService.register(req);
+
+        UserResponse updated = userService.enableMembership(resp.getId());
+        assertTrue(userRepository.findById(resp.getId()).orElseThrow().getMember());
+        assertEquals(resp.getId(), updated.getId());
+    }
+}


### PR DESCRIPTION
## Summary
- add portal endpoint to enable user membership
- implement `enableMembership` in `UserService`
- document the new endpoint in README
- test coverage for the new service and controller

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d65b9836c8332a5c8167714133095