### PR TITLE
新增Portal会员删除接口

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,5 @@ java -jar target/glancy-backend-0.0.1-SNAPSHOT.jar
 - `POST /api/portal/parameters` – create or update a runtime parameter
 - `GET /api/portal/parameters/{name}` – get the value of a parameter
 - `GET /api/portal/parameters` – list all parameters
+- `DELETE /api/portal/users/{id}/membership` – remove membership from a user
 

--- a/src/main/java/com/glancy/backend/controller/PortalController.java
+++ b/src/main/java/com/glancy/backend/controller/PortalController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import com.glancy.backend.dto.SystemParameterRequest;
 import com.glancy.backend.dto.SystemParameterResponse;
 import com.glancy.backend.service.SystemParameterService;
+import com.glancy.backend.service.UserService;
 
 /**
  * Portal endpoints used by administrators to adjust runtime
@@ -20,9 +21,12 @@ import com.glancy.backend.service.SystemParameterService;
 public class PortalController {
 
     private final SystemParameterService parameterService;
+    private final UserService userService;
 
-    public PortalController(SystemParameterService parameterService) {
+    public PortalController(SystemParameterService parameterService,
+                            UserService userService) {
         this.parameterService = parameterService;
+        this.userService = userService;
     }
 
     /**
@@ -51,5 +55,14 @@ public class PortalController {
     public ResponseEntity<List<SystemParameterResponse>> list() {
         List<SystemParameterResponse> resp = parameterService.list();
         return ResponseEntity.ok(resp);
+    }
+
+    /**
+     * Remove membership for a specific user.
+     */
+    @DeleteMapping("/users/{id}/membership")
+    public ResponseEntity<Void> removeMembership(@PathVariable Long id) {
+        userService.removeMembership(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/glancy/backend/service/UserService.java
+++ b/src/main/java/com/glancy/backend/service/UserService.java
@@ -174,4 +174,17 @@ public class UserService {
         return new ThirdPartyAccountResponse(saved.getId(), saved.getProvider(),
                 saved.getExternalId(), saved.getUser().getId());
     }
+
+    /**
+     * Remove membership for the given user.
+     */
+    @Transactional
+    public void removeMembership(Long userId) {
+        log.info("Removing membership for user {}", userId);
+        log.debug("Removing membership for user {}", userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("用户不存在"));
+        user.setMember(false);
+        userRepository.save(user);
+    }
 }

--- a/src/test/java/com/glancy/backend/controller/PortalControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/PortalControllerTest.java
@@ -1,0 +1,33 @@
+package com.glancy.backend.controller;
+
+import com.glancy.backend.service.SystemParameterService;
+import com.glancy.backend.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PortalController.class)
+class PortalControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SystemParameterService systemParameterService;
+
+    @MockBean
+    private UserService userService;
+
+    @Test
+    void removeMembership() throws Exception {
+        doNothing().when(userService).removeMembership(1L);
+        mockMvc.perform(delete("/api/portal/users/1/membership"))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/com/glancy/backend/service/UserServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/UserServiceTest.java
@@ -141,5 +141,22 @@ class UserServiceTest {
         List<LoginDevice> devices = loginDeviceRepository
                 .findByUserIdOrderByLoginTimeAsc(resp.getId());
         assertEquals(3, devices.size());
-        assertFalse(devices.stream().anyMatch(d -> "d1".equals(d.getDeviceInfo())));
-    }}
+        assertFalse(devices.stream().anyMatch(d -> "d1".equals(d.getDeviceInfo())));    }
+
+    @Test
+    void testRemoveMembership() {
+        UserRegistrationRequest req = new UserRegistrationRequest();
+        req.setUsername("memberuser");
+        req.setPassword("pass123");
+        req.setEmail("member@example.com");
+        UserResponse resp = userService.register(req);
+
+        User user = userRepository.findById(resp.getId()).orElseThrow();
+        user.setMember(true);
+        userRepository.save(user);
+
+        userService.removeMembership(resp.getId());
+        User updated = userRepository.findById(resp.getId()).orElseThrow();
+        assertFalse(updated.getMember());
+    }
+}


### PR DESCRIPTION
## Summary
- add endpoint in `PortalController` to remove membership for a user
- implement `removeMembership` in `UserService`
- document the new API in README
- add tests `PortalControllerTest` and service test for membership removal

## Testing
- `./mvnw test` *(failed: Network is unreachable while downloading Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_686d65c31cbc833286a0fe01853d7593