### PR TITLE
新增单词音标字段

### DIFF
--- a/src/main/java/com/glancy/backend/dto/WordResponse.java
+++ b/src/main/java/com/glancy/backend/dto/WordResponse.java
@@ -14,4 +14,5 @@ public class WordResponse {
     private List<String> definitions;
     private Language language;
     private String example;
+    private String phonetic;
 }

--- a/src/main/java/com/glancy/backend/entity/Word.java
+++ b/src/main/java/com/glancy/backend/entity/Word.java
@@ -30,6 +30,9 @@ public class Word {
     @Column(nullable = false, length = 10)
     private Language language;
 
+    @Column(length = 100)
+    private String phonetic;
+
     @Column
     private String example;
 

--- a/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -26,7 +26,7 @@ class WordControllerTest {
 
     @Test
     void testGetWord() throws Exception {
-        WordResponse resp = new WordResponse(1L, "hello", List.of("g"), Language.ENGLISH, "ex");
+        WordResponse resp = new WordResponse(1L, "hello", List.of("g"), Language.ENGLISH, "ex", "həˈloʊ");
         when(wordService.findWord(eq("hello"), eq(Language.ENGLISH))).thenReturn(resp);
 
         mockMvc.perform(get("/api/words")

--- a/src/test/java/com/glancy/backend/service/WordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/WordServiceTest.java
@@ -37,7 +37,7 @@ class WordServiceTest {
     @Test
     void testFindWord() {
         WordResponse resp = new WordResponse(1L, "hello",
-                List.of("greeting"), Language.ENGLISH, "Hello world");
+                List.of("greeting"), Language.ENGLISH, "Hello world", "həˈloʊ");
         when(deepSeekClient.fetchDefinition("hello", Language.ENGLISH))
                 .thenReturn(resp);
 


### PR DESCRIPTION
## Summary
- add `phonetic` property to `Word` entity
- include phonetic field in `WordResponse`
- update Word tests for new argument

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d6826e348833288a1f4372c984226