### PR TITLE
添加Ping接口

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ java -jar target/glancy-backend-0.0.1-SNAPSHOT.jar
 ```
 ## API Endpoints
 
+### Health
+- `GET /api/ping` – verify that the service is running
+
 ### Users
 - `POST /api/users/register` – register a new user
 - `DELETE /api/users/{id}` – logically delete a user

--- a/src/main/java/com/glancy/backend/controller/PingController.java
+++ b/src/main/java/com/glancy/backend/controller/PingController.java
@@ -1,0 +1,22 @@
+package com.glancy.backend.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Simple endpoint used by monitoring tools to verify the service is running.
+ */
+@RestController
+@RequestMapping("/api")
+public class PingController {
+
+    /**
+     * Respond with "pong" when the service is healthy.
+     */
+    @GetMapping("/ping")
+    public ResponseEntity<String> ping() {
+        return ResponseEntity.ok("pong");
+    }
+}

--- a/src/test/java/com/glancy/backend/controller/PingControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/PingControllerTest.java
@@ -1,0 +1,24 @@
+package com.glancy.backend.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PingController.class)
+class PingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void ping() throws Exception {
+        mockMvc.perform(get("/api/ping"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("pong"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `/api/ping` endpoint for quick health checks
- document the ping endpoint in the README

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686ff242d05883328dbe59c5736dc72b