### PR TITLE
新增最后登录时间和活跃统计

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,5 @@ java -jar target/glancy-backend-0.0.1-SNAPSHOT.jar
 - `GET /api/portal/parameters/{name}` – get the value of a parameter
 - `GET /api/portal/parameters` – list all parameters
 - `GET /api/portal/user-stats` – fetch overall user counts
+- `GET /api/portal/daily-active` – daily active users and rate
 

--- a/src/main/java/com/glancy/backend/controller/PortalController.java
+++ b/src/main/java/com/glancy/backend/controller/PortalController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import com.glancy.backend.dto.SystemParameterRequest;
 import com.glancy.backend.dto.SystemParameterResponse;
 import com.glancy.backend.dto.UserStatisticsResponse;
+import com.glancy.backend.dto.DailyActiveUserResponse;
 import com.glancy.backend.service.UserService;
 import com.glancy.backend.dto.LogLevelRequest;
 import com.glancy.backend.service.SystemParameterService;
@@ -67,6 +68,15 @@ public class PortalController {
     @GetMapping("/user-stats")
     public ResponseEntity<UserStatisticsResponse> userStats() {
         UserStatisticsResponse resp = userService.getStatistics();
+        return ResponseEntity.ok(resp);
+    }
+
+    /**
+     * Get today's active user stats.
+     */
+    @GetMapping("/daily-active")
+    public ResponseEntity<DailyActiveUserResponse> dailyActive() {
+        DailyActiveUserResponse resp = userService.getDailyActiveStats();
         return ResponseEntity.ok(resp);
     }
 

--- a/src/main/java/com/glancy/backend/dto/DailyActiveUserResponse.java
+++ b/src/main/java/com/glancy/backend/dto/DailyActiveUserResponse.java
@@ -1,0 +1,14 @@
+package com.glancy.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Daily active user statistics response.
+ */
+@Data
+@AllArgsConstructor
+public class DailyActiveUserResponse {
+    private long activeUsers;
+    private double activeRate;
+}

--- a/src/main/java/com/glancy/backend/entity/User.java
+++ b/src/main/java/com/glancy/backend/entity/User.java
@@ -1,7 +1,9 @@
 package com.glancy.backend.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.time.LocalDateTime;
 
 /**
@@ -34,7 +36,11 @@ public class User {
     @Column(nullable = false)
     private Boolean deleted = false;
 
-    @Column(nullable = false)    private Boolean member = false;
+    @Column(nullable = false)
+    private Boolean member = false;
 
     @Column(nullable = false)
-    private LocalDateTime createdAt = LocalDateTime.now();}
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    private LocalDateTime lastLoginAt;
+}

--- a/src/main/java/com/glancy/backend/repository/UserRepository.java
+++ b/src/main/java/com/glancy/backend/repository/UserRepository.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Repository;
 
 import com.glancy.backend.entity.User;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 /**
@@ -12,9 +13,15 @@ import java.util.Optional;
  */
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByUsernameAndDeletedFalse(String username);    Optional<User> findByEmailAndDeletedFalse(String email);
+    Optional<User> findByUsernameAndDeletedFalse(String username);
+
+    Optional<User> findByEmailAndDeletedFalse(String email);
 
     long countByDeletedTrue();
+
     long countByDeletedFalse();
+
     long countByDeletedFalseAndMemberTrue();
+
+    long countByDeletedFalseAndLastLoginAtAfter(LocalDateTime time);
 }

--- a/src/test/java/com/glancy/backend/controller/PortalControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/PortalControllerTest.java
@@ -2,6 +2,7 @@ package com.glancy.backend.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.glancy.backend.dto.UserStatisticsResponse;
+import com.glancy.backend.dto.DailyActiveUserResponse;
 import com.glancy.backend.dto.SystemParameterRequest;
 import com.glancy.backend.dto.SystemParameterResponse;
 import com.glancy.backend.service.UserService;
@@ -39,6 +40,15 @@ class PortalControllerTest {
         mockMvc.perform(get("/api/portal/user-stats"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalUsers").value(2));
+    }
+
+    @Test
+    void dailyActive() throws Exception {
+        DailyActiveUserResponse resp = new DailyActiveUserResponse(1, 0.5);
+        when(userService.getDailyActiveStats()).thenReturn(resp);
+        mockMvc.perform(get("/api/portal/daily-active"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activeUsers").value(1));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- 新增`lastLoginAt`字段到`User`实体
- 新增`DailyActiveUserResponse` DTO
- 登录时更新最后登录时间
- 新增`/api/portal/daily-active`接口及其测试
- 更新README文档

## Testing
- `./mvnw -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68726b5b2aa0833291fe90b803a51aa2