### PR TITLE
在启动时记录DB密码

### DIFF
--- a/src/main/java/com/glancy/backend/GlancyBackendApplication.java
+++ b/src/main/java/com/glancy/backend/GlancyBackendApplication.java
@@ -4,11 +4,13 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.client.RestTemplate;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Application entry point for the Glancy dictionary backend.
  */
 @SpringBootApplication
+@Slf4j
 public class GlancyBackendApplication {
     /**
      * Bootstraps the Spring application while loading DB credentials
@@ -17,6 +19,7 @@ public class GlancyBackendApplication {
     public static void main(String[] args) {
         io.github.cdimascio.dotenv.Dotenv dotenv = io.github.cdimascio.dotenv.Dotenv.configure().load();
         System.setProperty("DB_PASSWORD", dotenv.get("DB_PASSWORD"));
+        log.trace("Loaded DB_PASSWORD: {}", dotenv.get("DB_PASSWORD"));
         SpringApplication.run(GlancyBackendApplication.class, args);
     }
 


### PR DESCRIPTION
## Summary
- 为 `GlancyBackendApplication` 新增 `@Slf4j` 注解并在启动时以 TRACE 级别输出 `DB_PASSWORD`

## Testing
- `./mvnw test -q` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68726ad7438883329eeacf619aaf38f2