### PR TITLE
新增告警邮箱维护接口

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,7 @@ java -jar target/glancy-backend-0.0.1-SNAPSHOT.jar
 - `GET /api/portal/parameters/{name}` – get the value of a parameter
 - `GET /api/portal/parameters` – list all parameters
 - `GET /api/portal/user-stats` – fetch overall user counts
+- `POST /api/portal/alert-recipients` – add an alert email address
+- `GET /api/portal/alert-recipients` – list alert email addresses
+- `DELETE /api/portal/alert-recipients/{id}` – remove an alert email address
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,10 +38,14 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-mail</artifactId>
+                </dependency>
 
 		<dependency>
 			<groupId>com.mysql</groupId>

--- a/src/main/java/com/glancy/backend/controller/AlertRecipientController.java
+++ b/src/main/java/com/glancy/backend/controller/AlertRecipientController.java
@@ -1,0 +1,53 @@
+package com.glancy.backend.controller;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.glancy.backend.dto.AlertRecipientRequest;
+import com.glancy.backend.dto.AlertRecipientResponse;
+import com.glancy.backend.service.AlertRecipientService;
+
+/**
+ * Portal endpoints for managing alert recipient email addresses.
+ */
+@RestController
+@RequestMapping("/api/portal/alert-recipients")
+public class AlertRecipientController {
+
+    private final AlertRecipientService alertRecipientService;
+
+    public AlertRecipientController(AlertRecipientService alertRecipientService) {
+        this.alertRecipientService = alertRecipientService;
+    }
+
+    /**
+     * Add a new alert recipient email address.
+     */
+    @PostMapping
+    public ResponseEntity<AlertRecipientResponse> create(@Valid @RequestBody AlertRecipientRequest req) {
+        AlertRecipientResponse resp = alertRecipientService.addRecipient(req);
+        return new ResponseEntity<>(resp, HttpStatus.CREATED);
+    }
+
+    /**
+     * List all alert recipient email addresses.
+     */
+    @GetMapping
+    public ResponseEntity<List<AlertRecipientResponse>> list() {
+        List<AlertRecipientResponse> resp = alertRecipientService.listRecipients();
+        return ResponseEntity.ok(resp);
+    }
+
+    /**
+     * Remove an alert recipient by id.
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        alertRecipientService.deleteRecipient(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/glancy/backend/dto/AlertRecipientRequest.java
+++ b/src/main/java/com/glancy/backend/dto/AlertRecipientRequest.java
@@ -1,0 +1,15 @@
+package com.glancy.backend.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+/**
+ * Payload for creating a new alert recipient email address.
+ */
+@Data
+public class AlertRecipientRequest {
+    @NotBlank(message = "{validation.alertRecipient.email.notblank}")
+    @Email(message = "邮箱格式不正确")
+    private String email;
+}

--- a/src/main/java/com/glancy/backend/dto/AlertRecipientResponse.java
+++ b/src/main/java/com/glancy/backend/dto/AlertRecipientResponse.java
@@ -1,0 +1,14 @@
+package com.glancy.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * DTO representing an alert recipient email address.
+ */
+@Data
+@AllArgsConstructor
+public class AlertRecipientResponse {
+    private Long id;
+    private String email;
+}

--- a/src/main/java/com/glancy/backend/entity/AlertRecipient.java
+++ b/src/main/java/com/glancy/backend/entity/AlertRecipient.java
@@ -1,0 +1,21 @@
+package com.glancy.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Stores an email address that should receive alert notifications.
+ */
+@Entity
+@Table(name = "alert_recipients")
+@Data
+@NoArgsConstructor
+public class AlertRecipient {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+}

--- a/src/main/java/com/glancy/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/glancy/backend/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import com.glancy.backend.service.AlertService;
 
 /**
  * Handles application exceptions and logs them.
@@ -14,15 +15,23 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private final AlertService alertService;
+
+    public GlobalExceptionHandler(AlertService alertService) {
+        this.alertService = alertService;
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
         log.error("Request resulted in error: {}", ex.getMessage(), ex);
+        alertService.sendAlert("Illegal argument", ex.getMessage());
         return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception ex) {
         log.error("Unhandled exception", ex);
+        alertService.sendAlert("Unhandled exception", ex.getMessage());
         return new ResponseEntity<>(new ErrorResponse("内部服务器错误"), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/glancy/backend/repository/AlertRecipientRepository.java
+++ b/src/main/java/com/glancy/backend/repository/AlertRecipientRepository.java
@@ -1,0 +1,14 @@
+package com.glancy.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.glancy.backend.entity.AlertRecipient;
+
+/**
+ * Repository managing {@link AlertRecipient} records.
+ */
+@Repository
+public interface AlertRecipientRepository extends JpaRepository<AlertRecipient, Long> {
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/glancy/backend/service/AlertRecipientService.java
+++ b/src/main/java/com/glancy/backend/service/AlertRecipientService.java
@@ -1,0 +1,63 @@
+package com.glancy.backend.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.glancy.backend.dto.AlertRecipientRequest;
+import com.glancy.backend.dto.AlertRecipientResponse;
+import com.glancy.backend.entity.AlertRecipient;
+import com.glancy.backend.repository.AlertRecipientRepository;
+
+/**
+ * Business logic for managing alert recipient email addresses.
+ */
+@Service
+public class AlertRecipientService {
+
+    private final AlertRecipientRepository repository;
+
+    public AlertRecipientService(AlertRecipientRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * Add a new email address to the alert recipient list.
+     */
+    @Transactional
+    public AlertRecipientResponse addRecipient(AlertRecipientRequest request) {
+        if (repository.existsByEmail(request.getEmail())) {
+            AlertRecipient existing = repository.findAll().stream()
+                    .filter(r -> r.getEmail().equals(request.getEmail()))
+                    .findFirst().orElse(null);
+            return toResponse(existing);
+        }
+        AlertRecipient recipient = new AlertRecipient();
+        recipient.setEmail(request.getEmail());
+        AlertRecipient saved = repository.save(recipient);
+        return toResponse(saved);
+    }
+
+    /**
+     * Remove an email address by id.
+     */
+    @Transactional
+    public void deleteRecipient(Long id) {
+        repository.deleteById(id);
+    }
+
+    /**
+     * List all stored email addresses.
+     */
+    @Transactional(readOnly = true)
+    public List<AlertRecipientResponse> listRecipients() {
+        return repository.findAll().stream().map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    private AlertRecipientResponse toResponse(AlertRecipient recipient) {
+        return new AlertRecipientResponse(recipient.getId(), recipient.getEmail());
+    }
+}

--- a/src/main/java/com/glancy/backend/service/AlertService.java
+++ b/src/main/java/com/glancy/backend/service/AlertService.java
@@ -1,0 +1,51 @@
+package com.glancy.backend.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.glancy.backend.entity.AlertRecipient;
+import com.glancy.backend.repository.AlertRecipientRepository;
+
+/**
+ * Sends alert emails when errors occur.
+ */
+@Slf4j
+@Service
+public class AlertService {
+
+    private final JavaMailSender mailSender;
+    private final AlertRecipientRepository recipientRepository;
+
+    public AlertService(JavaMailSender mailSender,
+                        AlertRecipientRepository recipientRepository) {
+        this.mailSender = mailSender;
+        this.recipientRepository = recipientRepository;
+    }
+
+    /**
+     * Send an alert email with the provided subject and body.
+     */
+    public void sendAlert(String subject, String body) {
+        List<String> recipients = recipientRepository.findAll().stream()
+                .map(AlertRecipient::getEmail)
+                .filter(e -> e != null && !e.isBlank())
+                .collect(Collectors.toList());
+        if (recipients.isEmpty()) {
+            return;
+        }
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setTo(recipients.toArray(new String[0]));
+        msg.setSubject(subject);
+        msg.setText(body);
+        try {
+            mailSender.send(msg);
+        } catch (Exception e) {
+            log.error("Failed to send alert email", e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,9 @@ spring:
     name: glancy
   messages:
     basename: messages
+  mail:
+    host: localhost
+    port: 1025
   datasource:
     url: jdbc:mysql://localhost:3306/glancy_db?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=Asia/Shanghai&characterEncoding=utf8
     username: glancy_user

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -17,3 +17,4 @@ validation.userRegistration.email.notblank=Email must not be blank
 validation.searchRecord.language.notnull=Language must not be null
 validation.systemParameter.name.notblank=Parameter name must not be blank
 validation.systemParameter.value.notblank=Parameter value must not be blank
+validation.alertRecipient.email.notblank=Email must not be blank

--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -8,6 +8,7 @@ validation.notification.message.notblank=Die Benachrichtigungsnachricht darf nic
 validation.searchRecord.term.notblank=Der Suchbegriff darf nicht leer sein
 validation.thirdPartyAccount.provider.notblank=Der Anbieter darf nicht leer sein
 validation.thirdPartyAccount.externalId.notblank=Die externe ID darf nicht leer sein
+validation.alertRecipient.email.notblank=Die E-Mail darf nicht leer sein
 validation.userPreference.theme.notblank=Das Thema darf nicht leer sein
 validation.userPreference.systemLanguage.notblank=Die Systemsprache darf nicht leer sein
 validation.userPreference.searchLanguage.notblank=Die Suchsprache darf nicht leer sein

--- a/src/main/resources/messages_fr.properties
+++ b/src/main/resources/messages_fr.properties
@@ -8,6 +8,7 @@ validation.notification.message.notblank=Le message de notification ne doit pas 
 validation.searchRecord.term.notblank=Le terme de recherche ne doit pas être vide
 validation.thirdPartyAccount.provider.notblank=Le fournisseur ne doit pas être vide
 validation.thirdPartyAccount.externalId.notblank=L'ID externe ne doit pas être vide
+validation.alertRecipient.email.notblank=L'e-mail ne doit pas être vide
 validation.userPreference.theme.notblank=Le thème ne doit pas être vide
 validation.userPreference.systemLanguage.notblank=La langue du système ne doit pas être vide
 validation.userPreference.searchLanguage.notblank=La langue de recherche ne doit pas être vide

--- a/src/main/resources/messages_ja.properties
+++ b/src/main/resources/messages_ja.properties
@@ -8,6 +8,7 @@ validation.notification.message.notblank=通知メッセージは空白にでき
 validation.searchRecord.term.notblank=検索語は空白にできません
 validation.thirdPartyAccount.provider.notblank=プロバイダーは空白にできません
 validation.thirdPartyAccount.externalId.notblank=外部IDは空白にできません
+validation.alertRecipient.email.notblank=メールアドレスは空白にできません
 validation.userPreference.theme.notblank=テーマは空白にできません
 validation.userPreference.systemLanguage.notblank=システム言語は空白にできません
 validation.userPreference.searchLanguage.notblank=検索言語は空白にできません

--- a/src/main/resources/messages_ko.properties
+++ b/src/main/resources/messages_ko.properties
@@ -8,6 +8,7 @@ validation.notification.message.notblank=알림 메시지는 비워 둘 수 없�
 validation.searchRecord.term.notblank=검색어는 비워 둘 수 없습니다
 validation.thirdPartyAccount.provider.notblank=제공자는 비워 둘 수 없습니다
 validation.thirdPartyAccount.externalId.notblank=외부 ID는 비워 둘 수 없습니다
+validation.alertRecipient.email.notblank=이메일은 비워 둘 수 없습니다
 validation.userPreference.theme.notblank=테마는 비워 둘 수 없습니다
 validation.userPreference.systemLanguage.notblank=시스템 언어는 비워 둘 수 없습니다
 validation.userPreference.searchLanguage.notblank=검색 언어는 비워 둘 수 없습니다

--- a/src/main/resources/messages_ru.properties
+++ b/src/main/resources/messages_ru.properties
@@ -8,6 +8,7 @@ validation.notification.message.notblank=Текст уведомления не 
 validation.searchRecord.term.notblank=Поисковый запрос не должен быть пустым
 validation.thirdPartyAccount.provider.notblank=Провайдер не должен быть пустым
 validation.thirdPartyAccount.externalId.notblank=Внешний ID не должен быть пустым
+validation.alertRecipient.email.notblank=Электронная почта не должна быть пустой
 validation.userPreference.theme.notblank=Тема не должна быть пустой
 validation.userPreference.systemLanguage.notblank=Язык системы не должен быть пустым
 validation.userPreference.searchLanguage.notblank=Язык поиска не должен быть пустым

--- a/src/main/resources/messages_zh.properties
+++ b/src/main/resources/messages_zh.properties
@@ -17,3 +17,4 @@ validation.userRegistration.email.notblank=邮箱不能为空
 validation.searchRecord.language.notnull=语言不能为空
 validation.systemParameter.name.notblank=参数名不能为空
 validation.systemParameter.value.notblank=参数值不能为空
+validation.alertRecipient.email.notblank=邮箱不能为空


### PR DESCRIPTION
## Summary
- introduce `AlertRecipient` entity and repository
- add `AlertRecipientService` and new controller under `/api/portal/alert-recipients`
- update `AlertService` to send emails to all recipients from the database
- remove old single email config and document new endpoints
- add validation messages in multiple languages

## Testing
- `./mvnw test` *(failed: Network is unreachable while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68726a5d5f188332b26a707dfe4c2571