### PR TITLE
新增获取总用户数API

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ java -jar target/glancy-backend-0.0.1-SNAPSHOT.jar
 - `GET /api/users/{id}` – fetch user details
 - `POST /api/users/login` – user login
 - `POST /api/users/{id}/third-party-accounts` – bind a third‑party account (returns the bound account)
+- `GET /api/users/count` – total number of active users
 
 ### Notifications
 - `POST /api/notifications/system` – create a system notification

--- a/src/main/java/com/glancy/backend/controller/UserController.java
+++ b/src/main/java/com/glancy/backend/controller/UserController.java
@@ -96,4 +96,13 @@ public class UserController {
         AvatarResponse resp = userService.updateAvatar(id, req.getAvatar());
         return ResponseEntity.ok(resp);
     }
+
+    /**
+     * Get the total number of active users.
+     */
+    @GetMapping("/count")
+    public ResponseEntity<Long> countUsers() {
+        long count = userService.countActiveUsers();
+        return ResponseEntity.ok(count);
+    }
 }

--- a/src/main/java/com/glancy/backend/service/UserService.java
+++ b/src/main/java/com/glancy/backend/service/UserService.java
@@ -207,6 +207,14 @@ public class UserService {
     }
 
     /**
+     * Count all active (non-deleted) users.
+     */
+    @Transactional(readOnly = true)
+    public long countActiveUsers() {
+        return userRepository.countByDeletedFalse();
+    }
+
+    /**
      * Retrieve only the avatar URL of a user.
      */
     @Transactional(readOnly = true)

--- a/src/test/java/com/glancy/backend/controller/UserControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/UserControllerTest.java
@@ -124,4 +124,12 @@ class UserControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.avatar").value("url"));
     }
+
+    @Test
+    void countUsers() throws Exception {
+        when(userService.countActiveUsers()).thenReturn(5L);
+        mockMvc.perform(get("/api/users/count"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("5"));
+    }
 }

--- a/src/test/java/com/glancy/backend/service/UserServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/UserServiceTest.java
@@ -158,4 +158,23 @@ class UserServiceTest {
         AvatarResponse fetched = userService.getAvatar(resp.getId());
         assertEquals("url", fetched.getAvatar());
     }
+
+    @Test
+    void testCountActiveUsers() {
+        User u1 = new User();
+        u1.setUsername("a1");
+        u1.setPassword("p");
+        u1.setEmail("a1@example.com");
+        userRepository.save(u1);
+
+        User u2 = new User();
+        u2.setUsername("a2");
+        u2.setPassword("p");
+        u2.setEmail("a2@example.com");
+        u2.setDeleted(true);
+        userRepository.save(u2);
+
+        long count = userService.countActiveUsers();
+        assertEquals(1, count);
+    }
 }


### PR DESCRIPTION
## Summary
- add `/api/users/count` endpoint in `UserController`
- implement `countActiveUsers` in `UserService`
- document new endpoint in README
- cover service and controller logic with tests

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68727abaf78883328e697302e12ce34b