### PR TITLE
新增修改用户名接口

### DIFF
--- a/src/main/java/com/glancy/backend/controller/UserController.java
+++ b/src/main/java/com/glancy/backend/controller/UserController.java
@@ -13,6 +13,8 @@ import com.glancy.backend.dto.ThirdPartyAccountRequest;
 import com.glancy.backend.dto.ThirdPartyAccountResponse;
 import com.glancy.backend.dto.AvatarRequest;
 import com.glancy.backend.dto.AvatarResponse;
+import com.glancy.backend.dto.UsernameRequest;
+import com.glancy.backend.dto.UsernameResponse;
 import com.glancy.backend.entity.User;
 import com.glancy.backend.service.UserService;
 
@@ -94,6 +96,17 @@ public class UserController {
             @PathVariable Long id,
             @Valid @RequestBody AvatarRequest req) {
         AvatarResponse resp = userService.updateAvatar(id, req.getAvatar());
+        return ResponseEntity.ok(resp);
+    }
+
+    /**
+     * Update the username for a user.
+     */
+    @PutMapping("/{id}/username")
+    public ResponseEntity<UsernameResponse> updateUsername(
+            @PathVariable Long id,
+            @Valid @RequestBody UsernameRequest req) {
+        UsernameResponse resp = userService.updateUsername(id, req.getUsername());
         return ResponseEntity.ok(resp);
     }
 

--- a/src/main/java/com/glancy/backend/dto/UserResponse.java
+++ b/src/main/java/com/glancy/backend/dto/UserResponse.java
@@ -12,4 +12,6 @@ public class UserResponse {
     private Long id;
     private String username;
     private String email;
-    private String avatar;    private String phone;}
+    private String avatar;
+    private String phone;
+}

--- a/src/main/java/com/glancy/backend/dto/UsernameRequest.java
+++ b/src/main/java/com/glancy/backend/dto/UsernameRequest.java
@@ -1,0 +1,13 @@
+package com.glancy.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+/**
+ * Request body used when updating a user's username.
+ */
+@Data
+public class UsernameRequest {
+    @NotBlank(message = "用户名不能为空")
+    private String username;
+}

--- a/src/main/java/com/glancy/backend/dto/UsernameResponse.java
+++ b/src/main/java/com/glancy/backend/dto/UsernameResponse.java
@@ -1,0 +1,13 @@
+package com.glancy.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Returned when querying or updating a user's username.
+ */
+@Data
+@AllArgsConstructor
+public class UsernameResponse {
+    private String username;
+}

--- a/src/main/java/com/glancy/backend/service/UserService.java
+++ b/src/main/java/com/glancy/backend/service/UserService.java
@@ -12,6 +12,7 @@ import com.glancy.backend.dto.UserResponse;
 import com.glancy.backend.dto.ThirdPartyAccountRequest;
 import com.glancy.backend.dto.ThirdPartyAccountResponse;
 import com.glancy.backend.dto.AvatarResponse;
+import com.glancy.backend.dto.UsernameResponse;
 import com.glancy.backend.dto.DailyActiveUserResponse;
 import com.glancy.backend.entity.User;
 import com.glancy.backend.entity.LoginDevice;
@@ -236,5 +237,21 @@ public class UserService {
         user.setAvatar(avatar);
         User saved = userRepository.save(user);
         return new AvatarResponse(saved.getAvatar());
+    }
+
+    /**
+     * Update the username for the specified user.
+     */
+    @Transactional
+    public UsernameResponse updateUsername(Long userId, String username) {
+        log.info("Updating username for user {}", userId);
+        userRepository.findByUsernameAndDeletedFalse(username).ifPresent(u -> {
+            throw new IllegalArgumentException("用户名已存在");
+        });
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("用户不存在"));
+        user.setUsername(username);
+        User saved = userRepository.save(user);
+        return new UsernameResponse(saved.getUsername());
     }
 }


### PR DESCRIPTION
## Summary
- 增加 `UsernameRequest` 和 `UsernameResponse` DTO
- 在 `UserService` 新增 `updateUsername` 方法
- 在 `UserController` 添加更新用户名的端点
- 修复 `UserResponse` 的格式问题

## Testing
- `./mvnw -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68728ec5aee88332bd52c92104d4ffe7