### PR TITLE
新增单词发音文件接口

### DIFF
--- a/src/main/java/com/glancy/backend/client/DeepSeekClient.java
+++ b/src/main/java/com/glancy/backend/client/DeepSeekClient.java
@@ -6,6 +6,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 
 @Component
 public class DeepSeekClient {
@@ -25,5 +29,22 @@ public class DeepSeekClient {
                 .queryParam("language", language.name().toLowerCase())
                 .toUriString();
         return restTemplate.getForObject(url, WordResponse.class);
+    }
+
+    public byte[] fetchAudio(String term, Language language) {
+        String url = UriComponentsBuilder.fromHttpUrl(baseUrl)
+                .path("/words/audio")
+                .queryParam("term", term)
+                .queryParam("language", language.name().toLowerCase())
+                .toUriString();
+        HttpHeaders headers = new HttpHeaders();
+        HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
+        ResponseEntity<byte[]> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                requestEntity,
+                byte[].class
+        );
+        return response.getBody();
     }
 }

--- a/src/main/java/com/glancy/backend/controller/WordController.java
+++ b/src/main/java/com/glancy/backend/controller/WordController.java
@@ -5,6 +5,7 @@ import com.glancy.backend.dto.SearchRecordRequest;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.service.WordService;
 import com.glancy.backend.service.SearchRecordService;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,5 +41,15 @@ public class WordController {
         searchRecordService.saveRecord(userId, req);
         WordResponse resp = wordService.findWord(term, language);
         return ResponseEntity.ok(resp);
+    }
+
+    /**
+     * Retrieve the pronunciation audio for a word.
+     */
+    @GetMapping(value = "/audio", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    public ResponseEntity<byte[]> getAudio(@RequestParam String term,
+                                           @RequestParam Language language) {
+        byte[] data = wordService.getAudio(term, language);
+        return ResponseEntity.ok(data);
     }
 }

--- a/src/main/java/com/glancy/backend/service/WordService.java
+++ b/src/main/java/com/glancy/backend/service/WordService.java
@@ -27,4 +27,10 @@ public class WordService {
         log.info("Fetching definition for term '{}' in language {}", term, language);
         return deepSeekClient.fetchDefinition(term, language);
     }
+
+    @Transactional(readOnly = true)
+    public byte[] getAudio(String term, Language language) {
+        log.info("Fetching audio for term '{}' in language {}", term, language);
+        return deepSeekClient.fetchAudio(term, language);
+    }
 }

--- a/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -37,4 +37,15 @@ class WordControllerTest {
                 .andExpect(jsonPath("$.id").value(1L))
                 .andExpect(jsonPath("$.term").value("hello"));
     }
+
+    @Test
+    void testGetAudio() throws Exception {
+        byte[] data = new byte[] {1, 2, 3};
+        when(wordService.getAudio(eq("hello"), eq(Language.ENGLISH))).thenReturn(data);
+
+        mockMvc.perform(get("/api/words/audio")
+                        .param("term", "hello")
+                        .param("language", "ENGLISH"))
+                .andExpect(status().isOk());
+    }
 }

--- a/src/test/java/com/glancy/backend/service/WordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/WordServiceTest.java
@@ -44,4 +44,13 @@ class WordServiceTest {
         WordResponse result = wordService.findWord("hello", Language.ENGLISH);
         assertEquals("greeting", result.getDefinitions().get(0));
     }
+
+    @Test
+    void testGetAudio() {
+        byte[] data = new byte[] {1, 2, 3};
+        when(deepSeekClient.fetchAudio("hello", Language.ENGLISH)).thenReturn(data);
+
+        byte[] result = wordService.getAudio("hello", Language.ENGLISH);
+        assertArrayEquals(data, result);
+    }
 }


### PR DESCRIPTION
## Summary
- extend `DeepSeekClient` with `fetchAudio` for retrieving pronunciation files
- add `getAudio` method in `WordService`
- expose `/api/words/audio` endpoint in `WordController`
- cover new functionality with controller and service tests

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68728e91fff08332bd78f4a3239a222c