### PR TITLE
新增 ChatGPT 客户端

### DIFF
--- a/src/main/java/com/glancy/backend/client/ChatGptClient.java
+++ b/src/main/java/com/glancy/backend/client/ChatGptClient.java
@@ -1,0 +1,62 @@
+package com.glancy.backend.client;
+
+import com.glancy.backend.dto.ChatGptResponse;
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ChatGptClient {
+    private final RestTemplate restTemplate;
+    private final String baseUrl;
+    private final String apiKey;
+
+    public ChatGptClient(RestTemplate restTemplate,
+                         @Value("${openai.base-url:https://api.openai.com/v1}") String baseUrl,
+                         @Value("${openai.api-key:}") String apiKey) {
+        this.restTemplate = restTemplate;
+        this.baseUrl = baseUrl;
+        this.apiKey = apiKey;
+    }
+
+    public WordResponse fetchDefinition(String term, Language language) {
+        String url = baseUrl + "/chat/completions";
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        if (apiKey != null && !apiKey.isEmpty()) {
+            headers.setBearerAuth(apiKey);
+        }
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("model", "gpt-3.5-turbo");
+        List<Map<String, String>> messages = List.of(
+                Map.of("role", "system", "content", "You are a dictionary assistant."),
+                Map.of(
+                        "role",
+                        "user",
+                        "content",
+                        "Define '" + term + "' in "
+                                + language.name().toLowerCase()
+                                + " and provide synonyms separated by comma."
+                )
+        );
+        payload.put("messages", messages);
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(payload, headers);
+        ChatGptResponse resp = restTemplate.postForObject(url, entity, ChatGptResponse.class);
+        String content = "";
+        if (resp != null && resp.getChoices() != null && !resp.getChoices().isEmpty()) {
+            content = resp.getChoices().get(0).getMessage().getContent();
+        }
+        return new WordResponse(null, term, List.of(content), language, null, null);
+    }
+}

--- a/src/main/java/com/glancy/backend/controller/WordController.java
+++ b/src/main/java/com/glancy/backend/controller/WordController.java
@@ -33,12 +33,15 @@ public class WordController {
     @GetMapping
     public ResponseEntity<WordResponse> getWord(@RequestParam Long userId,
                                                 @RequestParam String term,
-                                                @RequestParam Language language) {
+                                                @RequestParam Language language,
+                                                @RequestParam(name = "gpt", required = false, defaultValue = "false") boolean gpt) {
         SearchRecordRequest req = new SearchRecordRequest();
         req.setTerm(term);
         req.setLanguage(language);
         searchRecordService.saveRecord(userId, req);
-        WordResponse resp = wordService.findWord(term, language);
+        WordResponse resp = gpt ?
+                wordService.findWordWithGpt(term, language) :
+                wordService.findWord(term, language);
         return ResponseEntity.ok(resp);
     }
 }

--- a/src/main/java/com/glancy/backend/dto/ChatGptResponse.java
+++ b/src/main/java/com/glancy/backend/dto/ChatGptResponse.java
@@ -1,0 +1,20 @@
+package com.glancy.backend.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ChatGptResponse {
+    private List<Choice> choices;
+
+    @Data
+    public static class Choice {
+        private Message message;
+    }
+
+    @Data
+    public static class Message {
+        private String content;
+    }
+}

--- a/src/main/java/com/glancy/backend/service/WordService.java
+++ b/src/main/java/com/glancy/backend/service/WordService.java
@@ -3,6 +3,7 @@ package com.glancy.backend.service;
 import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.client.DeepSeekClient;
+import com.glancy.backend.client.ChatGptClient;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,9 +15,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class WordService {
     private final DeepSeekClient deepSeekClient;
+    private final ChatGptClient chatGptClient;
 
-    public WordService(DeepSeekClient deepSeekClient) {
+    public WordService(DeepSeekClient deepSeekClient, ChatGptClient chatGptClient) {
         this.deepSeekClient = deepSeekClient;
+        this.chatGptClient = chatGptClient;
     }
 
     /**
@@ -26,5 +29,14 @@ public class WordService {
     public WordResponse findWord(String term, Language language) {
         log.info("Fetching definition for term '{}' in language {}", term, language);
         return deepSeekClient.fetchDefinition(term, language);
+    }
+
+    /**
+     * Retrieve word details using ChatGPT.
+     */
+    @Transactional(readOnly = true)
+    public WordResponse findWordWithGpt(String term, Language language) {
+        log.info("Fetching definition for term '{}' using ChatGPT in language {}", term, language);
+        return chatGptClient.fetchDefinition(term, language);
     }
 }

--- a/src/test/java/com/glancy/backend/service/WordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/WordServiceTest.java
@@ -47,4 +47,15 @@ class WordServiceTest {
         WordResponse result = wordService.findWord("hello", Language.ENGLISH);
         assertEquals("greeting", result.getDefinitions().get(0));
     }
+
+    @Test
+    void testFindWordWithGpt() {
+        WordResponse resp = new WordResponse(null, "hi",
+                List.of("salutation"), Language.ENGLISH, null, null);
+        when(chatGptClient.fetchDefinition("hi", Language.ENGLISH))
+                .thenReturn(resp);
+
+        WordResponse result = wordService.findWordWithGpt("hi", Language.ENGLISH);
+        assertEquals("salutation", result.getDefinitions().get(0));
+    }
 }

--- a/src/test/java/com/glancy/backend/service/WordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/WordServiceTest.java
@@ -3,6 +3,7 @@ package com.glancy.backend.service;
 import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.Language;
 import com.glancy.backend.client.DeepSeekClient;
+import com.glancy.backend.client.ChatGptClient;
 import io.github.cdimascio.dotenv.Dotenv;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,8 @@ class WordServiceTest {
     private WordService wordService;
     @MockBean
     private DeepSeekClient deepSeekClient;
+    @MockBean
+    private ChatGptClient chatGptClient;
 
     @BeforeAll
     static void loadEnv() {


### PR DESCRIPTION
## Summary
- add `ChatGptClient` to call OpenAI API
- expose optional `gpt` parameter in `WordController`
- allow `WordService` to fetch definitions using ChatGPT
- adjust tests for new dependency

## Testing
- `./mvnw -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68728fad00588332a4bad345442eaa65