### PR TITLE
Improve test configuration

### DIFF
--- a/src/test/java/com/glancy/backend/config/TestMailConfig.java
+++ b/src/test/java/com/glancy/backend/config/TestMailConfig.java
@@ -1,0 +1,15 @@
+package com.glancy.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class TestMailConfig {
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        return new JavaMailSenderImpl();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+    datasource:
+        url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL
+        driver-class-name: org.h2.Driver
+        username: sa
+        password:
+    jpa:
+        hibernate:
+            ddl-auto: update
+        show-sql: false
+        properties:
+            hibernate:
+                dialect: org.hibernate.dialect.MySQLDialect
+                globally_quoted_identifiers: true


### PR DESCRIPTION
## Summary
- add a simple JavaMailSender bean for tests
- provide H2 configuration for tests

## Testing
- `mvn -q test` *(fails: Domain "TEXT" not found when creating tables)*

------
https://chatgpt.com/codex/tasks/task_e_68729193eca48332b59e3b82b0598ac0