### PR TITLE
添加更新告警邮箱接口

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Example curl commands live in `CURL_TESTS.md`. Run `scripts/curl-tests.sh` to ca
 - `GET /api/portal/user-stats` – fetch overall user counts
 - `POST /api/portal/alert-recipients` – add an alert email address
 - `GET /api/portal/alert-recipients` – list alert email addresses
+- `PUT /api/portal/alert-recipients/{id}` – update an alert email address
 - `DELETE /api/portal/alert-recipients/{id}` – remove an alert email address
 - `GET /api/portal/daily-active` – daily active users and rate
 

--- a/scripts/curl-tests.sh
+++ b/scripts/curl-tests.sh
@@ -91,6 +91,11 @@ curl -i -H "Content-Type: application/json" \
 section "List alert recipients"
 curl -i "$BASE_URL/api/portal/alert-recipients"
 
+section "Update alert recipient"
+curl -i -X PUT -H "Content-Type: application/json" \
+    -d '{"email":"alert2@example.com"}' \
+    "$BASE_URL/api/portal/alert-recipients/1"
+
 section "Delete alert recipient"
 curl -i -X DELETE "$BASE_URL/api/portal/alert-recipients/1"
 

--- a/src/main/java/com/glancy/backend/controller/AlertRecipientController.java
+++ b/src/main/java/com/glancy/backend/controller/AlertRecipientController.java
@@ -34,6 +34,16 @@ public class AlertRecipientController {
     }
 
     /**
+     * Update an alert recipient email address.
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<AlertRecipientResponse> update(@PathVariable Long id,
+            @Valid @RequestBody AlertRecipientRequest req) {
+        AlertRecipientResponse resp = alertRecipientService.updateRecipient(id, req);
+        return ResponseEntity.ok(resp);
+    }
+
+    /**
      * List all alert recipient email addresses.
      */
     @GetMapping

--- a/src/main/java/com/glancy/backend/service/AlertRecipientService.java
+++ b/src/main/java/com/glancy/backend/service/AlertRecipientService.java
@@ -41,6 +41,21 @@ public class AlertRecipientService {
     }
 
     /**
+     * Update an existing email address.
+     */
+    @Transactional
+    public AlertRecipientResponse updateRecipient(Long id, AlertRecipientRequest request) {
+        AlertRecipient recipient = repository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("收件人不存在"));
+        if (!recipient.getEmail().equals(request.getEmail()) && repository.existsByEmail(request.getEmail())) {
+            throw new IllegalArgumentException("邮箱已存在");
+        }
+        recipient.setEmail(request.getEmail());
+        AlertRecipient saved = repository.save(recipient);
+        return toResponse(saved);
+    }
+
+    /**
      * Remove an email address by id.
      */
     @Transactional

--- a/src/test/java/com/glancy/backend/controller/AlertRecipientControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/AlertRecipientControllerTest.java
@@ -1,0 +1,83 @@
+package com.glancy.backend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.glancy.backend.dto.AlertRecipientRequest;
+import com.glancy.backend.dto.AlertRecipientResponse;
+import com.glancy.backend.service.AlertRecipientService;
+import com.glancy.backend.service.AlertService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AlertRecipientController.class)
+class AlertRecipientControllerTest {
+    @MockBean
+    private AlertService alertService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AlertRecipientService alertRecipientService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void createRecipient() throws Exception {
+        AlertRecipientResponse resp = new AlertRecipientResponse(1L, "a@example.com");
+        when(alertRecipientService.addRecipient(any(AlertRecipientRequest.class))).thenReturn(resp);
+
+        AlertRecipientRequest req = new AlertRecipientRequest();
+        req.setEmail("a@example.com");
+
+        mockMvc.perform(post("/api/portal/alert-recipients")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1L));
+    }
+
+    @Test
+    void listRecipients() throws Exception {
+        when(alertRecipientService.listRecipients()).thenReturn(List.of(new AlertRecipientResponse(1L, "a@example.com")));
+
+        mockMvc.perform(get("/api/portal/alert-recipients"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1L));
+    }
+
+    @Test
+    void updateRecipient() throws Exception {
+        AlertRecipientResponse resp = new AlertRecipientResponse(1L, "b@example.com");
+        when(alertRecipientService.updateRecipient(eq(1L), any(AlertRecipientRequest.class))).thenReturn(resp);
+
+        AlertRecipientRequest req = new AlertRecipientRequest();
+        req.setEmail("b@example.com");
+
+        mockMvc.perform(put("/api/portal/alert-recipients/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("b@example.com"));
+    }
+
+    @Test
+    void deleteRecipient() throws Exception {
+        doNothing().when(alertRecipientService).deleteRecipient(1L);
+        mockMvc.perform(delete("/api/portal/alert-recipients/1"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/glancy/backend/service/AlertRecipientServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/AlertRecipientServiceTest.java
@@ -1,0 +1,56 @@
+package com.glancy.backend.service;
+
+import com.glancy.backend.dto.AlertRecipientRequest;
+import com.glancy.backend.dto.AlertRecipientResponse;
+import com.glancy.backend.entity.AlertRecipient;
+import com.glancy.backend.repository.AlertRecipientRepository;
+import io.github.cdimascio.dotenv.Dotenv;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class AlertRecipientServiceTest {
+
+    @Autowired
+    private AlertRecipientService alertRecipientService;
+    @Autowired
+    private AlertRecipientRepository alertRecipientRepository;
+
+    @BeforeAll
+    static void loadEnv() {
+        Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+        String dbPassword = dotenv.get("DB_PASSWORD");
+        if (dbPassword != null) {
+            System.setProperty("DB_PASSWORD", dbPassword);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        alertRecipientRepository.deleteAll();
+    }
+
+    @Test
+    void testAddAndUpdateRecipient() {
+        AlertRecipientRequest req = new AlertRecipientRequest();
+        req.setEmail("a@example.com");
+        AlertRecipientResponse resp = alertRecipientService.addRecipient(req);
+        assertNotNull(resp.getId());
+        assertEquals("a@example.com", resp.getEmail());
+
+        AlertRecipientRequest updateReq = new AlertRecipientRequest();
+        updateReq.setEmail("b@example.com");
+        AlertRecipientResponse updated = alertRecipientService.updateRecipient(resp.getId(), updateReq);
+        assertEquals("b@example.com", updated.getEmail());
+
+        AlertRecipient entity = alertRecipientRepository.findById(resp.getId()).orElseThrow();
+        assertEquals("b@example.com", entity.getEmail());
+    }
+}


### PR DESCRIPTION
## Summary
- allow updating alert recipient emails
- document the new endpoint in README and curl script
- add unit tests for AlertRecipient controller and service

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_6872aa176ff083328974298143c75aed