### PR TITLE
服务启动邮件提醒

### DIFF
--- a/src/main/java/com/glancy/backend/listener/StartupNotificationListener.java
+++ b/src/main/java/com/glancy/backend/listener/StartupNotificationListener.java
@@ -1,0 +1,26 @@
+package com.glancy.backend.listener;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.glancy.backend.service.AlertService;
+
+/**
+ * Sends a startup notification email to all alert recipients when the
+ * application is fully initialized.
+ */
+@Component
+public class StartupNotificationListener {
+
+    private final AlertService alertService;
+
+    public StartupNotificationListener(AlertService alertService) {
+        this.alertService = alertService;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationReady() {
+        alertService.sendAlert("服务启动", "Glancy 后端服务已启动");
+    }
+}


### PR DESCRIPTION
## Summary
- 新增 `StartupNotificationListener`，在 `ApplicationReadyEvent` 触发时给所有告警邮箱发送“服务启动”通知

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_6872a9ebc35c833299402880b81dfbe5