### PR TITLE
新增DeepSeek查询

### DIFF
--- a/CURL_TESTS.md
+++ b/CURL_TESTS.md
@@ -25,3 +25,9 @@ curl -i -H "Content-Type: application/json" \
 ```
 
 更多示例请查看 README.md 以及上述脚本。
+
+### 查询单词
+
+```bash
+curl -i "http://localhost:8080/api/words?userId=1&term=hello&language=ENGLISH"
+```

--- a/scripts/curl-tests.sh
+++ b/scripts/curl-tests.sh
@@ -63,6 +63,9 @@ curl -i -H "Content-Type: application/json" \
 section "List search records"
 curl -i "$BASE_URL/api/search-records/user/1"
 
+section "Lookup word"
+curl -i "$BASE_URL/api/words?userId=1&term=hello&language=ENGLISH"
+
 section "Clear search records"
 curl -i -X DELETE "$BASE_URL/api/search-records/user/1"
 

--- a/src/main/java/com/glancy/backend/GlancyBackendApplication.java
+++ b/src/main/java/com/glancy/backend/GlancyBackendApplication.java
@@ -19,6 +19,10 @@ public class GlancyBackendApplication {
     public static void main(String[] args) {
         io.github.cdimascio.dotenv.Dotenv dotenv = io.github.cdimascio.dotenv.Dotenv.configure().load();
         System.setProperty("DB_PASSWORD", dotenv.get("DB_PASSWORD"));
+        String apiKey = dotenv.get("deepseek.api-key");
+        if (apiKey != null) {
+            System.setProperty("deepseek.api-key", apiKey);
+        }
         log.info("Loaded DB_PASSWORD: {}", dotenv.get("DB_PASSWORD"));
         SpringApplication.run(GlancyBackendApplication.class, args);
     }

--- a/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -30,12 +30,13 @@ class WordControllerTest {
     @MockBean
     private AlertService alertService;
 
-    // @Test
+    @Test
     void testGetWord() throws Exception {
         WordResponse resp = new WordResponse(1L, "hello", List.of("g"), Language.ENGLISH, "ex", "həˈloʊ");
         when(wordService.findWordFromDeepSeek(eq("hello"), eq(Language.ENGLISH))).thenReturn(resp);
 
         mockMvc.perform(get("/api/words")
+                        .param("userId", "1")
                         .param("term", "hello")
                         .param("language", "ENGLISH")
                         .accept(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
## Summary
- 加入 deepseek.api-key 读取逻辑
- DeepSeekClient 支持设置鉴权头
- 补充 /api/words 的单元测试
- 更新 curl 脚本与文档

## Testing
- `./mvnw test -q`

------
https://chatgpt.com/codex/tasks/task_e_6872c2d09a6c8332899c3fdc1aec25d3