### PR TITLE
Add email notification toggle

### DIFF
--- a/scripts/curl-tests.sh
+++ b/scripts/curl-tests.sh
@@ -102,6 +102,12 @@ curl -i -X PUT -H "Content-Type: application/json" \
 section "Delete alert recipient"
 curl -i -X DELETE "$BASE_URL/api/portal/alert-recipients/1"
 
+section "Set email notifications enabled"
+curl -i -X POST "$BASE_URL/api/portal/email-enabled?enabled=true"
+
+section "Get email notifications enabled"
+curl -i "$BASE_URL/api/portal/email-enabled"
+
 section "Record portal traffic"
 curl -i -H "Content-Type: application/json" \
     -d '{"path":"/","ip":"127.0.0.1","userAgent":"curl"}' \

--- a/src/main/java/com/glancy/backend/controller/PortalController.java
+++ b/src/main/java/com/glancy/backend/controller/PortalController.java
@@ -27,6 +27,7 @@ public class PortalController {
     private final SystemParameterService parameterService;
     private final UserService userService;
     private final LoggingService loggingService;
+    private static final String EMAIL_PARAM = "email.notifications.enabled";
 
     public PortalController(
             SystemParameterService parameterService,
@@ -109,5 +110,30 @@ public class PortalController {
             @Valid @RequestBody LogLevelRequest req) {
         loggingService.setLogLevel(req.getLogger(), req.getLevel());
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * Enable or disable alert emails globally.
+     */
+    @PostMapping("/email-enabled")
+    public ResponseEntity<Void> setEmailEnabled(@RequestParam boolean enabled) {
+        SystemParameterRequest req = new SystemParameterRequest();
+        req.setName(EMAIL_PARAM);
+        req.setValue(Boolean.toString(enabled));
+        parameterService.upsert(req);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * Check if alert emails are enabled. Defaults to false.
+     */
+    @GetMapping("/email-enabled")
+    public ResponseEntity<Boolean> isEmailEnabled() {
+        try {
+            SystemParameterResponse resp = parameterService.getByName(EMAIL_PARAM);
+            return ResponseEntity.ok(Boolean.parseBoolean(resp.getValue()));
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.ok(false);
+        }
     }
 }

--- a/src/main/java/com/glancy/backend/entity/SystemParameter.java
+++ b/src/main/java/com/glancy/backend/entity/SystemParameter.java
@@ -20,6 +20,6 @@ public class SystemParameter {
     @Column(nullable = false, unique = true, length = 50)
     private String name;
 
-    @Column(nullable = false, length = 255)
+    @Column(name = "param_value", nullable = false, length = 255)
     private String value;
 }

--- a/src/test/java/com/glancy/backend/controller/PortalControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/PortalControllerTest.java
@@ -86,4 +86,25 @@ class PortalControllerTest {
         mockMvc.perform(delete("/api/portal/users/1/member"))
                 .andExpect(status().isOk());
     }
+
+    @Test
+    void setEmailEnabled() throws Exception {
+        SystemParameterResponse resp = new SystemParameterResponse(1L,
+                "email.notifications.enabled", "true");
+        when(parameterService.upsert(any(SystemParameterRequest.class)))
+                .thenReturn(resp);
+        mockMvc.perform(post("/api/portal/email-enabled?enabled=true"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void getEmailEnabled() throws Exception {
+        SystemParameterResponse resp = new SystemParameterResponse(1L,
+                "email.notifications.enabled", "true");
+        when(parameterService.getByName("email.notifications.enabled"))
+                .thenReturn(resp);
+        mockMvc.perform(get("/api/portal/email-enabled"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("true"));
+    }
 }

--- a/src/test/java/com/glancy/backend/service/AlertServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/AlertServiceTest.java
@@ -1,0 +1,75 @@
+package com.glancy.backend.service;
+
+import com.glancy.backend.entity.AlertRecipient;
+import com.glancy.backend.entity.SystemParameter;
+import com.glancy.backend.repository.AlertRecipientRepository;
+import com.glancy.backend.repository.SystemParameterRepository;
+import io.github.cdimascio.dotenv.Dotenv;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@Transactional
+class AlertServiceTest {
+
+    @Autowired
+    private AlertService alertService;
+    @Autowired
+    private AlertRecipientRepository alertRecipientRepository;
+    @Autowired
+    private SystemParameterRepository parameterRepository;
+
+    @MockBean
+    private JavaMailSender mailSender;
+
+    @BeforeAll
+    static void loadEnv() {
+        Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+        String dbPassword = dotenv.get("DB_PASSWORD");
+        if (dbPassword != null) {
+            System.setProperty("DB_PASSWORD", dbPassword);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        alertRecipientRepository.deleteAll();
+        parameterRepository.deleteAll();
+    }
+
+    @Test
+    void sendAlertDisabled() {
+        AlertRecipient r = new AlertRecipient();
+        r.setEmail("a@example.com");
+        alertRecipientRepository.save(r);
+
+        alertService.sendAlert("s", "b");
+
+        verify(mailSender, never()).send(any(SimpleMailMessage.class));
+    }
+
+    @Test
+    void sendAlertEnabled() {
+        AlertRecipient r = new AlertRecipient();
+        r.setEmail("a@example.com");
+        alertRecipientRepository.save(r);
+
+        SystemParameter p = new SystemParameter();
+        p.setName("email.notifications.enabled");
+        p.setValue("true");
+        parameterRepository.save(p);
+
+        alertService.sendAlert("s", "b");
+
+        verify(mailSender, times(1)).send(any(SimpleMailMessage.class));
+    }
+}


### PR DESCRIPTION
## Summary
- add email notification toggle in PortalController
- prevent alert emails when disabled via SystemParameter
- store system parameter value under `param_value` column
- extend curl tests and unit tests

## Testing
- `./mvnw test -q`

------
https://chatgpt.com/codex/tasks/task_e_6872dcb2f298833292674c42cd3c64ed