### PR TITLE
新增登录检查，限制未登录查词

### DIFF
--- a/src/main/java/com/glancy/backend/service/SearchRecordService.java
+++ b/src/main/java/com/glancy/backend/service/SearchRecordService.java
@@ -43,6 +43,10 @@ public class SearchRecordService {
                     log.warn("User with id {} not found", userId);
                     return new IllegalArgumentException("用户不存在");
                 });
+        if (user.getLastLoginAt() == null) {
+            log.warn("User {} is not logged in", userId);
+            throw new IllegalStateException("用户未登录");
+        }
         if (Boolean.FALSE.equals(user.getMember())) {
             LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
             LocalDateTime endOfDay = startOfDay.plusDays(1);

--- a/src/test/java/com/glancy/backend/service/SearchRecordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/SearchRecordServiceTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -51,6 +52,8 @@ class SearchRecordServiceTest {
         user.setPassword("p");
         user.setEmail("s@example.com");
         userRepository.save(user);
+        user.setLastLoginAt(LocalDateTime.now());
+        userRepository.save(user);
 
         SearchRecordRequest req = new SearchRecordRequest();
         req.setTerm("hello");
@@ -64,5 +67,22 @@ class SearchRecordServiceTest {
 
         searchRecordService.clearRecords(user.getId());
         assertTrue(searchRecordService.getRecords(user.getId()).isEmpty());
+    }
+
+    @Test
+    void testSaveRecordWithoutLogin() {
+        User user = new User();
+        user.setUsername("nologin");
+        user.setPassword("p");
+        user.setEmail("n@example.com");
+        userRepository.save(user);
+
+        SearchRecordRequest req = new SearchRecordRequest();
+        req.setTerm("hi");
+        req.setLanguage(Language.ENGLISH);
+
+        Exception ex = assertThrows(IllegalStateException.class,
+                () -> searchRecordService.saveRecord(user.getId(), req));
+        assertEquals("用户未登录", ex.getMessage());
     }
 }


### PR DESCRIPTION
## Summary
- enforce login check when saving search records
- update tests to cover login requirements

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_687350e50a18833293b8f69b4efdfe41