### PR TITLE
删除日志中的敏感信息

### DIFF
--- a/src/main/java/com/glancy/backend/GlancyBackendApplication.java
+++ b/src/main/java/com/glancy/backend/GlancyBackendApplication.java
@@ -23,7 +23,6 @@ public class GlancyBackendApplication {
         if (apiKey != null) {
             System.setProperty("deepseek.api-key", apiKey);
         }
-        log.info("Loaded DB_PASSWORD: {}", dotenv.get("DB_PASSWORD"));
         SpringApplication.run(GlancyBackendApplication.class, args);
     }
 


### PR DESCRIPTION
## Summary
- 删除 `GlancyBackendApplication.java` 中记录 DB 密码的日志

## Testing
- `./mvnw test` *(passes)*
- `./mvnw spring-boot:run -DskipTests` *(fails: Could not find `.env` on the classpath, but未打印密码)*

------
https://chatgpt.com/codex/tasks/task_e_68773bde08b88332a7a2cae3a5309d76