### PR TITLE
隐藏密码字段

### DIFF
--- a/src/main/java/com/glancy/backend/entity/User.java
+++ b/src/main/java/com/glancy/backend/entity/User.java
@@ -1,6 +1,7 @@
 package com.glancy.backend.entity;
 
 import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -21,6 +22,7 @@ public class User {
     @Column(nullable = false, unique = true, length = 50)
     private String username;
 
+    @JsonIgnore
     @Column(nullable = false)
     private String password;
 

--- a/src/test/java/com/glancy/backend/controller/UserControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/UserControllerTest.java
@@ -68,7 +68,8 @@ class UserControllerTest {
 
         mockMvc.perform(get("/api/users/1"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(1L));
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.password").doesNotExist());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- 使用 `@JsonIgnore` 标注 `User` 实体中的 `password` 字段，防止序列化
- 更新 `UserControllerTest.getUser`，确认接口响应不含 `password`

## Testing
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_68773bdcf36c8332817d9f31a88b00ad