### PR TITLE
第三方配置前缀调整

### DIFF
--- a/scripts/curl-tests.sh
+++ b/scripts/curl-tests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Quick API smoke test using curl
 # BASE_URL defaults to http://localhost:8080
+# Optional third-party URLs can be set with environment variables like
+# THIRDPARTY_DEEPSEEK_BASE_URL or THIRDPARTY_OPENAI_BASE_URL.
 
 BASE_URL=${BASE_URL:-http://localhost:8080}
 

--- a/src/main/java/com/glancy/backend/GlancyBackendApplication.java
+++ b/src/main/java/com/glancy/backend/GlancyBackendApplication.java
@@ -19,9 +19,9 @@ public class GlancyBackendApplication {
     public static void main(String[] args) {
         io.github.cdimascio.dotenv.Dotenv dotenv = io.github.cdimascio.dotenv.Dotenv.configure().load();
         System.setProperty("DB_PASSWORD", dotenv.get("DB_PASSWORD"));
-        String apiKey = dotenv.get("deepseek.api-key");
+        String apiKey = dotenv.get("thirdparty.deepseek.api-key");
         if (apiKey != null) {
-            System.setProperty("deepseek.api-key", apiKey);
+            System.setProperty("thirdparty.deepseek.api-key", apiKey);
         }
         log.info("Loaded DB_PASSWORD: {}", dotenv.get("DB_PASSWORD"));
         SpringApplication.run(GlancyBackendApplication.class, args);

--- a/src/main/java/com/glancy/backend/client/ChatGptClient.java
+++ b/src/main/java/com/glancy/backend/client/ChatGptClient.java
@@ -21,8 +21,8 @@ public class ChatGptClient {
     private final String apiKey;
 
     public ChatGptClient(RestTemplate restTemplate,
-                         @Value("${openai.base-url:https://api.openai.com/v1}") String baseUrl,
-                         @Value("${openai.api-key:}") String apiKey) {
+                         @Value("${thirdparty.openai.base-url:https://api.openai.com/v1}") String baseUrl,
+                         @Value("${thirdparty.openai.api-key:}") String apiKey) {
         this.restTemplate = restTemplate;
         this.baseUrl = baseUrl;
         this.apiKey = apiKey;

--- a/src/main/java/com/glancy/backend/client/DeepSeekClient.java
+++ b/src/main/java/com/glancy/backend/client/DeepSeekClient.java
@@ -18,8 +18,8 @@ public class DeepSeekClient {
     private final String apiKey;
 
     public DeepSeekClient(RestTemplate restTemplate,
-                          @Value("${deepseek.base-url:https://api.deepseek.com}") String baseUrl,
-                          @Value("${deepseek.api-key:}") String apiKey) {
+                          @Value("${thirdparty.deepseek.base-url:https://api.deepseek.com}") String baseUrl,
+                          @Value("${thirdparty.deepseek.api-key:}") String apiKey) {
         this.restTemplate = restTemplate;
         this.baseUrl = baseUrl;
         this.apiKey = apiKey;

--- a/src/main/java/com/glancy/backend/client/GeminiClient.java
+++ b/src/main/java/com/glancy/backend/client/GeminiClient.java
@@ -16,7 +16,7 @@ public class GeminiClient {
     private final String baseUrl;
 
     public GeminiClient(RestTemplate restTemplate,
-                        @Value("${gemini.base-url:https://api.gemini.com}") String baseUrl) {
+                        @Value("${thirdparty.gemini.base-url:https://api.gemini.com}") String baseUrl) {
         this.restTemplate = restTemplate;
         this.baseUrl = baseUrl;
     }

--- a/src/main/java/com/glancy/backend/client/GoogleTtsClient.java
+++ b/src/main/java/com/glancy/backend/client/GoogleTtsClient.java
@@ -12,7 +12,7 @@ public class GoogleTtsClient {
     private final String baseUrl;
 
     public GoogleTtsClient(RestTemplate restTemplate,
-                           @Value("${google.tts-base-url:https://translate.google.com}") String baseUrl) {
+                           @Value("${thirdparty.google-tts.base-url:https://translate.google.com}") String baseUrl) {
         this.restTemplate = restTemplate;
         this.baseUrl = baseUrl;
     }

--- a/src/main/java/com/glancy/backend/client/QianWenClient.java
+++ b/src/main/java/com/glancy/backend/client/QianWenClient.java
@@ -16,7 +16,7 @@ public class QianWenClient {
     private final String baseUrl;
 
     public QianWenClient(RestTemplate restTemplate,
-                         @Value("${qianwen.base-url:https://api.qianwen.com}") String baseUrl) {
+                         @Value("${thirdparty.qianwen.base-url:https://api.qianwen.com}") String baseUrl) {
         this.restTemplate = restTemplate;
         this.baseUrl = baseUrl;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,5 +34,13 @@ logging:
 thirdparty:
     deepseek:
         base-url: https://api.deepseek.com
+        api-key: ''
     gemini:
         base-url: https://api.gemini.com
+    openai:
+        base-url: https://api.openai.com/v1
+        api-key: ''
+    qianwen:
+        base-url: https://api.qianwen.com
+    google-tts:
+        base-url: https://translate.google.com


### PR DESCRIPTION
## Summary
- update third-party client property prefixes to `thirdparty.<service>.base-url`
- keep matching prefix entries in `application.yml`
- reference new environment variables in curl test script

## Testing
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_68773bc7dde48332841077b2b0ada77b