### PR TITLE
新增通知排序功能

### DIFF
--- a/src/main/java/com/glancy/backend/repository/NotificationRepository.java
+++ b/src/main/java/com/glancy/backend/repository/NotificationRepository.java
@@ -14,4 +14,8 @@ import com.glancy.backend.entity.Notification;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     List<Notification> findBySystemLevelTrue();
     List<Notification> findByUserId(Long userId);
+
+    List<Notification> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    List<Notification> findBySystemLevelTrueOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/glancy/backend/service/NotificationService.java
+++ b/src/main/java/com/glancy/backend/service/NotificationService.java
@@ -67,8 +67,9 @@ public class NotificationService {
     public List<NotificationResponse> getNotificationsForUser(Long userId) {
         log.info("Fetching notifications for user {}", userId);
         List<Notification> result = new ArrayList<>();
-        result.addAll(notificationRepository.findBySystemLevelTrue());
-        result.addAll(notificationRepository.findByUserId(userId));
+        result.addAll(notificationRepository.findBySystemLevelTrueOrderByCreatedAtDesc());
+        result.addAll(notificationRepository.findByUserIdOrderByCreatedAtDesc(userId));
+        result.sort((a, b) -> b.getCreatedAt().compareTo(a.getCreatedAt()));
         return result.stream().map(this::toResponse).collect(Collectors.toList());
     }
 

--- a/src/test/java/com/glancy/backend/controller/NotificationControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/NotificationControllerTest.java
@@ -66,11 +66,13 @@ class NotificationControllerTest {
 
     @Test
     void getNotificationsForUser() throws Exception {
-        NotificationResponse resp = new NotificationResponse(1L, "msg", false, 2L);
-        when(notificationService.getNotificationsForUser(2L)).thenReturn(List.of(resp));
+        NotificationResponse uresp = new NotificationResponse(1L, "user", false, 2L);
+        NotificationResponse sresp = new NotificationResponse(2L, "sys", true, null);
+        when(notificationService.getNotificationsForUser(2L)).thenReturn(List.of(uresp, sresp));
 
         mockMvc.perform(get("/api/notifications/user/2"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].userId").value(2L));
+                .andExpect(jsonPath("$[0].message").value("user"))
+                .andExpect(jsonPath("$[1].message").value("sys"));
     }
 }

--- a/src/test/java/com/glancy/backend/service/NotificationServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/NotificationServiceTest.java
@@ -66,5 +66,7 @@ class NotificationServiceTest {
 
         List<NotificationResponse> list = notificationService.getNotificationsForUser(user.getId());
         assertEquals(2, list.size());
+        assertEquals("user msg", list.get(0).getMessage());
+        assertEquals("sys msg", list.get(1).getMessage());
     }
 }


### PR DESCRIPTION
## Summary
- 增加 `NotificationRepository` 按 `createdAt` 排序的查询方法
- `NotificationService#getNotificationsForUser` 合并通知后按时间降序排序
- 更新 `NotificationServiceTest` 与 `NotificationControllerTest`

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_68773bbd7738833290e6485db07a777f