### PR TITLE
完善自动部署流程及版本说明

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,22 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
+      - name: 判定是否需要部署
+        id: version_check
+        run: |
+          current_version=$(grep -A1 '<artifactId>glancy-backend</artifactId>' pom.xml | grep '<version>' | sed -E 's/.*<version>(.*)<\/version>.*/\1/')
+          previous_version=$(git show HEAD~1:pom.xml | grep -A1 '<artifactId>glancy-backend</artifactId>' | grep '<version>' | sed -E 's/.*<version>(.*)<\/version>.*/\1/' || echo '')
+          curr_minor=$(echo "$current_version" | cut -d. -f2)
+          prev_minor=$(echo "$previous_version" | cut -d. -f2)
+          if [ "$curr_minor" != "$prev_minor" ]; then
+            echo "deploy=true" >> $GITHUB_OUTPUT
+          else
+            echo "deploy=false" >> $GITHUB_OUTPUT
+          fi
+          echo "version=$current_version" >> $GITHUB_OUTPUT
+
       - name: Setup SSH
+        if: steps.version_check.outputs.deploy == 'true'
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/id_rsa
@@ -21,9 +36,10 @@ jobs:
           ssh-keyscan -H ${{ secrets.REMOTE_HOST }} >> ~/.ssh/known_hosts
           ssh-keyscan -H github.com >> ~/.ssh/known_hosts
 
-      - name: Deploy to Remote Server
+      - name: 部署到远程服务器
+        if: steps.version_check.outputs.deploy == 'true'
         run: |
-          ssh ${{ secrets.REMOTE_USER }}@${{ secrets.REMOTE_HOST }} << 'EOF'
+          ssh ${{ secrets.REMOTE_USER }}@${{ secrets.REMOTE_HOST }} << 'EOF2'
             set -e
             cd /home/ecs-user/glancy-backend
 
@@ -46,7 +62,8 @@ jobs:
             fi
 
             echo "🚀 启动新服务"
-            nohup java -jar target/glancy-backend-0.0.1-SNAPSHOT.jar > backend.log 2>&1 &
+            nohup java -jar target/glancy-backend-${{ steps.version_check.outputs.version }}.jar > backend.log 2>&1 &
 
             echo "✅ 部署完成"
-          EOF
+          EOF2
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,8 @@ This project is a Spring Boot backend. Contributors should follow these rules:
 - 更新 `scripts/curl-tests.sh` 等脚本，以便通过 curl 对新接口进行验证。
 - 提交信息建议使用中文描述；如需创建分支，feature 名称应使用英文。
 
+## 版本管理
+- 项目版本号定义在 `pom.xml` 中。
+- 默认每次合并仅递增补丁版本号，即最后一位加一。
+- 若需要提升中版本号，应在 PR 中声明，此类变更会触发 GitHub Actions 的自动部署流程。
+

--- a/README.md
+++ b/README.md
@@ -92,3 +92,8 @@ Example curl commands live in `CURL_TESTS.md`. Run `scripts/curl-tests.sh` to ca
 - `DELETE /api/portal/alert-recipients/{id}` – remove an alert email address
 - `GET /api/portal/daily-active` – daily active users and rate
 
+
+## 版本管理
+
+项目版本号定义在 `pom.xml` 中。默认合并时只递增补丁版本号。若提升中版本号，请在 PR 中说明，GitHub Actions 会在检测到中版本号变更时自动部署。
+


### PR DESCRIPTION
## Summary
- 更新 deploy.yml，新增版本号检测逻辑，只有中版本号变化时才执行部署，并动态拼接 JAR 名称
- 在 README 中新增 "版本管理" 一节，说明默认递增补丁版本号，提升中版本号会触发自动部署

## Testing
- `./mvnw -q test`

------
https://chatgpt.com/codex/tasks/task_e_68773c6bee7083329bc02e0f123fffcf