### PR TITLE
调整SSL配置并新增本地配置文件

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ Glancy Backend is a Spring Boot service that powers the Glancy dictionary applic
 
 1. Clone this repository.
 2. Provide a `DB_PASSWORD` value via a `.env` file or environment variable.
-3. Ensure MySQL is running with a database named `glancy_db` and credentials as defined in `src/main/resources/application.yml`.
-4. Configure optional API base URLs in `application.yml` under the `thirdparty` section.
+3. Ensure MySQL is running with a database named `glancy_db`, matching credentials, and SSL certificates configured as `useSSL=true` requires.
+4. Use the `local` Spring profile if SSL is unavailable: `./mvnw spring-boot:run -Dspring.profiles.active=local`.
+5. Configure optional API base URLs in `application.yml` under the `thirdparty` section.
+Ensure the MySQL server provides SSL certificates trusted by the JVM. Configure the truststore if necessary when running with `useSSL=true`.
+
 
 ## Database Initialization
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,12 @@
+spring:
+    datasource:
+        url: jdbc:mysql://localhost:3306/glancy_db?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=Asia/Shanghai&characterEncoding=utf8
+        username: glancy_user
+        password: ${DB_PASSWORD}
+        driver-class-name: com.mysql.cj.jdbc.Driver
+
+    jpa:
+        hibernate:
+            ddl-auto: update
+        show-sql: true
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
         host: localhost
         port: 1025
     datasource:
-        url: jdbc:mysql://localhost:3306/glancy_db?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=Asia/Shanghai&characterEncoding=utf8
+        url: jdbc:mysql://localhost:3306/glancy_db?useSSL=true&serverTimezone=Asia/Shanghai&characterEncoding=utf8
         username: glancy_user
         password: ${DB_PASSWORD}
         driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## Summary
- update datasource URL to use `useSSL=true`
- add separate `application-local.yml`
- document SSL requirement and local profile in README

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_68773bdad1148332b8b8a05e42155ea8