### PR TITLE
新增安全配置

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,10 @@
                 </dependency>
                 <dependency>
                         <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-security</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-mail</artifactId>
                 </dependency>
 
@@ -57,16 +61,21 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-crypto</artifactId>
-			<version>5.8.0</version> 
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-crypto</artifactId>
+                        <version>5.8.0</version>
+                </dependency>
 		<dependency>
 			<groupId>io.github.cdimascio</groupId>
 			<artifactId>dotenv-java</artifactId>

--- a/scripts/curl-tests.sh
+++ b/scripts/curl-tests.sh
@@ -3,6 +3,7 @@
 # BASE_URL defaults to http://localhost:8080
 
 BASE_URL=${BASE_URL:-http://localhost:8080}
+ADMIN_AUTH="-u admin:password"
 
 function section() {
     echo -e "\n== $1 =="
@@ -30,7 +31,7 @@ section "List FAQs"
 curl -i "$BASE_URL/api/faqs"
 
 section "Create system notification"
-curl -i -H "Content-Type: application/json" \
+curl -i $ADMIN_AUTH -H "Content-Type: application/json" \
     -d '{"message":"System notice"}' \
     "$BASE_URL/api/notifications/system"
 
@@ -70,49 +71,49 @@ section "Clear search records"
 curl -i -X DELETE "$BASE_URL/api/search-records/user/1"
 
 section "Portal user stats"
-curl -i "$BASE_URL/api/portal/user-stats"
+curl -i $ADMIN_AUTH "$BASE_URL/api/portal/user-stats"
 
 section "Daily active users"
-curl -i "$BASE_URL/api/portal/daily-active"
+curl -i $ADMIN_AUTH "$BASE_URL/api/portal/daily-active"
 
 section "Add system parameter"
-curl -i -H "Content-Type: application/json" \
+curl -i $ADMIN_AUTH -H "Content-Type: application/json" \
     -d '{"name":"motd","value":"hello"}' \
     "$BASE_URL/api/portal/parameters"
 
 section "Get system parameter"
-curl -i "$BASE_URL/api/portal/parameters/motd"
+curl -i $ADMIN_AUTH "$BASE_URL/api/portal/parameters/motd"
 
 section "List system parameters"
-curl -i "$BASE_URL/api/portal/parameters"
+curl -i $ADMIN_AUTH "$BASE_URL/api/portal/parameters"
 
 section "Add alert recipient"
-curl -i -H "Content-Type: application/json" \
+curl -i $ADMIN_AUTH -H "Content-Type: application/json" \
     -d '{"email":"alert@example.com"}' \
     "$BASE_URL/api/portal/alert-recipients"
 
 section "List alert recipients"
-curl -i "$BASE_URL/api/portal/alert-recipients"
+curl -i $ADMIN_AUTH "$BASE_URL/api/portal/alert-recipients"
 
 section "Update alert recipient"
-curl -i -X PUT -H "Content-Type: application/json" \
+curl -i -X PUT $ADMIN_AUTH -H "Content-Type: application/json" \
     -d '{"email":"alert2@example.com"}' \
     "$BASE_URL/api/portal/alert-recipients/1"
 
 section "Delete alert recipient"
-curl -i -X DELETE "$BASE_URL/api/portal/alert-recipients/1"
+curl -i -X DELETE $ADMIN_AUTH "$BASE_URL/api/portal/alert-recipients/1"
 
 section "Set email notifications enabled"
-curl -i -X POST "$BASE_URL/api/portal/email-enabled?enabled=true"
+curl -i -X POST $ADMIN_AUTH "$BASE_URL/api/portal/email-enabled?enabled=true"
 
 section "Get email notifications enabled"
-curl -i "$BASE_URL/api/portal/email-enabled"
+curl -i $ADMIN_AUTH "$BASE_URL/api/portal/email-enabled"
 
 section "Record portal traffic"
-curl -i -H "Content-Type: application/json" \
+curl -i $ADMIN_AUTH -H "Content-Type: application/json" \
     -d '{"path":"/","ip":"127.0.0.1","userAgent":"curl"}' \
     "$BASE_URL/api/portal/traffic"
 
 section "Daily traffic counts"
-curl -i "$BASE_URL/api/portal/traffic/daily?start=2024-01-01&end=2024-01-02"
+curl -i $ADMIN_AUTH "$BASE_URL/api/portal/traffic/daily?start=2024-01-01&end=2024-01-02"
 

--- a/src/main/java/com/glancy/backend/config/SecurityConfig.java
+++ b/src/main/java/com/glancy/backend/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.glancy.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/portal/**", "/api/notifications/system").authenticated()
+                .anyRequest().permitAll()
+            )
+            .httpBasic();
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService users() {
+        return new InMemoryUserDetailsManager(
+            User.withUsername("admin").password("{noop}password").roles("ADMIN").build()
+        );
+    }
+}

--- a/src/test/java/com/glancy/backend/controller/AlertRecipientControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/AlertRecipientControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.context.annotation.Import;
 
 import java.util.List;
 
@@ -20,8 +21,10 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 
 @WebMvcTest(AlertRecipientController.class)
+@Import(com.glancy.backend.config.SecurityConfig.class)
 class AlertRecipientControllerTest {
     @MockBean
     private AlertService alertService;
@@ -44,6 +47,7 @@ class AlertRecipientControllerTest {
         req.setEmail("a@example.com");
 
         mockMvc.perform(post("/api/portal/alert-recipients")
+                        .with(httpBasic("admin", "password"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isCreated())
@@ -54,7 +58,7 @@ class AlertRecipientControllerTest {
     void listRecipients() throws Exception {
         when(alertRecipientService.listRecipients()).thenReturn(List.of(new AlertRecipientResponse(1L, "a@example.com")));
 
-        mockMvc.perform(get("/api/portal/alert-recipients"))
+        mockMvc.perform(get("/api/portal/alert-recipients").with(httpBasic("admin", "password")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(1L));
     }
@@ -68,6 +72,7 @@ class AlertRecipientControllerTest {
         req.setEmail("b@example.com");
 
         mockMvc.perform(put("/api/portal/alert-recipients/1")
+                        .with(httpBasic("admin", "password"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isOk())
@@ -77,7 +82,7 @@ class AlertRecipientControllerTest {
     @Test
     void deleteRecipient() throws Exception {
         doNothing().when(alertRecipientService).deleteRecipient(1L);
-        mockMvc.perform(delete("/api/portal/alert-recipients/1"))
+        mockMvc.perform(delete("/api/portal/alert-recipients/1").with(httpBasic("admin", "password")))
                 .andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/glancy/backend/controller/ContactControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/ContactControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.context.annotation.Import;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -18,6 +19,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(ContactController.class)
+@Import(com.glancy.backend.config.SecurityConfig.class)
 class ContactControllerTest {
 
     @MockBean

--- a/src/test/java/com/glancy/backend/controller/FaqControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/FaqControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.context.annotation.Import;
 
 import java.util.List;
 
@@ -20,6 +21,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(FaqController.class)
+@Import(com.glancy.backend.config.SecurityConfig.class)
 class FaqControllerTest {
 
     @MockBean

--- a/src/test/java/com/glancy/backend/controller/NotificationControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/NotificationControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.context.annotation.Import;
 
 import java.util.List;
 
@@ -19,8 +20,10 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 
 @WebMvcTest(NotificationController.class)
+@Import(com.glancy.backend.config.SecurityConfig.class)
 class NotificationControllerTest {
     @MockBean
     private AlertService alertService;
@@ -43,6 +46,7 @@ class NotificationControllerTest {
         req.setMessage("msg");
 
         mockMvc.perform(post("/api/notifications/system")
+                        .with(httpBasic("admin", "password"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isCreated())

--- a/src/test/java/com/glancy/backend/controller/PingControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/PingControllerTest.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.context.annotation.Import;
 import com.glancy.backend.service.AlertService;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -12,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(PingController.class)
+@Import(com.glancy.backend.config.SecurityConfig.class)
 class PingControllerTest {
     @MockBean
     private AlertService alertService;

--- a/src/test/java/com/glancy/backend/controller/PortalControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/PortalControllerTest.java
@@ -15,14 +15,17 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.context.annotation.Import;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 
 @WebMvcTest(PortalController.class)
+@Import(com.glancy.backend.config.SecurityConfig.class)
 class PortalControllerTest {
     @MockBean
     private AlertService alertService;
@@ -45,7 +48,7 @@ class PortalControllerTest {
     void userStats() throws Exception {
         UserStatisticsResponse resp = new UserStatisticsResponse(2, 1, 0);
         when(userService.getStatistics()).thenReturn(resp);
-        mockMvc.perform(get("/api/portal/user-stats"))
+        mockMvc.perform(get("/api/portal/user-stats").with(httpBasic("admin", "password")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalUsers").value(2));
     }
@@ -54,7 +57,7 @@ class PortalControllerTest {
     void dailyActive() throws Exception {
         DailyActiveUserResponse resp = new DailyActiveUserResponse(1, 0.5);
         when(userService.getDailyActiveStats()).thenReturn(resp);
-        mockMvc.perform(get("/api/portal/daily-active"))
+        mockMvc.perform(get("/api/portal/daily-active").with(httpBasic("admin", "password")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.activeUsers").value(1));
     }
@@ -67,6 +70,7 @@ class PortalControllerTest {
         req.setName("n");
         req.setValue("v");
         mockMvc.perform(post("/api/portal/parameters")
+                        .with(httpBasic("admin", "password"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isCreated())
@@ -76,14 +80,14 @@ class PortalControllerTest {
     @Test
     void activateMember() throws Exception {
         doNothing().when(userService).activateMembership(1L);
-        mockMvc.perform(post("/api/portal/users/1/member"))
+        mockMvc.perform(post("/api/portal/users/1/member").with(httpBasic("admin", "password")))
                 .andExpect(status().isOk());
     }
 
     @Test
     void removeMember() throws Exception {
         doNothing().when(userService).removeMembership(1L);
-        mockMvc.perform(delete("/api/portal/users/1/member"))
+        mockMvc.perform(delete("/api/portal/users/1/member").with(httpBasic("admin", "password")))
                 .andExpect(status().isOk());
     }
 
@@ -93,7 +97,7 @@ class PortalControllerTest {
                 "email.notifications.enabled", "true");
         when(parameterService.upsert(any(SystemParameterRequest.class)))
                 .thenReturn(resp);
-        mockMvc.perform(post("/api/portal/email-enabled?enabled=true"))
+        mockMvc.perform(post("/api/portal/email-enabled?enabled=true").with(httpBasic("admin", "password")))
                 .andExpect(status().isOk());
     }
 
@@ -103,7 +107,7 @@ class PortalControllerTest {
                 "email.notifications.enabled", "true");
         when(parameterService.getByName("email.notifications.enabled"))
                 .thenReturn(resp);
-        mockMvc.perform(get("/api/portal/email-enabled"))
+        mockMvc.perform(get("/api/portal/email-enabled").with(httpBasic("admin", "password")))
                 .andExpect(status().isOk())
                 .andExpect(content().string("true"));
     }

--- a/src/test/java/com/glancy/backend/controller/PortalTrafficControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/PortalTrafficControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.context.annotation.Import;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -20,8 +21,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 
 @WebMvcTest(PortalTrafficController.class)
+@Import(com.glancy.backend.config.SecurityConfig.class)
 class PortalTrafficControllerTest {
     @MockBean
     private AlertService alertService;
@@ -48,6 +51,7 @@ class PortalTrafficControllerTest {
         req.setUserAgent("ua");
 
         mockMvc.perform(post("/api/portal/traffic")
+                        .with(httpBasic("admin", "password"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isCreated())
@@ -61,6 +65,7 @@ class PortalTrafficControllerTest {
                 .thenReturn(List.of(5L, 3L));
 
         mockMvc.perform(get("/api/portal/traffic/daily")
+                        .with(httpBasic("admin", "password"))
                         .param("start", "2024-01-01")
                         .param("end", "2024-01-02"))
                 .andExpect(status().isOk())

--- a/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.context.annotation.Import;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -21,6 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(SearchRecordController.class)
+@Import(com.glancy.backend.config.SecurityConfig.class)
 class SearchRecordControllerTest {
     @MockBean
     private AlertService alertService;

--- a/src/test/java/com/glancy/backend/controller/UserControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/UserControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.context.annotation.Import;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -20,6 +21,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(UserController.class)
+@Import(com.glancy.backend.config.SecurityConfig.class)
 class UserControllerTest {
     @MockBean
     private AlertService alertService;

--- a/src/test/java/com/glancy/backend/controller/UserPreferenceControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/UserPreferenceControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.context.annotation.Import;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -19,6 +20,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(UserPreferenceController.class)
+@Import(com.glancy.backend.config.SecurityConfig.class)
 class UserPreferenceControllerTest {
     @MockBean
     private AlertService alertService;

--- a/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.context.annotation.Import;
 
 import java.util.List;
 
@@ -20,6 +21,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(WordController.class)
+@Import(com.glancy.backend.config.SecurityConfig.class)
 class WordControllerTest {
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
## Summary
- 添加 `SecurityConfig` 引入基本认证
- `pom.xml` 新增 Spring Security 依赖及测试依赖
- `/api/portal/**` 与 `/api/notifications/system` 需要认证
- 更新控制器单元测试以使用 `httpBasic`
- `curl-tests.sh` 新增管理员认证参数

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_68773bdaba2c8332aee8769acc97b8d6