### PR TITLE
添加单词缓存并更新测试

### DIFF
--- a/src/test/java/com/glancy/backend/service/WordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/WordServiceTest.java
@@ -6,8 +6,11 @@ import com.glancy.backend.client.DeepSeekClient;
 import com.glancy.backend.client.ChatGptClient;
 import com.glancy.backend.client.GoogleTtsClient;
 import com.glancy.backend.client.GeminiClient;
+import com.glancy.backend.entity.Word;
+import com.glancy.backend.repository.WordRepository;
 import io.github.cdimascio.dotenv.Dotenv;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest
 @Transactional
@@ -30,6 +33,8 @@ class WordServiceTest {
     private ChatGptClient chatGptClient;
     private GoogleTtsClient googleTtsClient;
     private GeminiClient geminiClient;
+    @Autowired
+    private WordRepository wordRepository;
 
     @BeforeAll
     static void loadEnv() {
@@ -40,16 +45,39 @@ class WordServiceTest {
         }
     }
 
+    @BeforeEach
+    void setUp() {
+        wordRepository.deleteAll();
+    }
+
 
     @Test
-    void testFindWord() {
-        WordResponse resp = new WordResponse(1L, "hello",
+    void testFetchAndCacheWord() {
+        WordResponse resp = new WordResponse(null, "hello",
                 List.of("greeting"), Language.ENGLISH, "Hello world", "həˈloʊ");
         when(deepSeekClient.fetchDefinition("hello", Language.ENGLISH))
                 .thenReturn(resp);
 
         WordResponse result = wordService.findWordFromDeepSeek("hello", Language.ENGLISH);
+
+        assertNotNull(result.getId());
         assertEquals("greeting", result.getDefinitions().get(0));
+        verify(deepSeekClient, times(1)).fetchDefinition("hello", Language.ENGLISH);
+        assertTrue(wordRepository.findById(result.getId()).isPresent());
+    }
+
+    @Test
+    void testUseCachedWord() {
+        Word word = new Word();
+        word.setTerm("cached");
+        word.setLanguage(Language.ENGLISH);
+        word.setDefinitions(List.of("store"));
+        wordRepository.save(word);
+
+        WordResponse result = wordService.findWordFromDeepSeek("cached", Language.ENGLISH);
+
+        assertEquals(word.getId(), result.getId());
+        verify(deepSeekClient, never()).fetchDefinition(anyString(), any());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- 实现 `WordService` 本地缓存逻辑
- 新增缓存相关单元测试

## Testing
- `./mvnw test -q`

------
https://chatgpt.com/codex/tasks/task_e_68773b5299ac8332862cf7d04392fa6e