### PR TITLE
新增法语prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ Example curl commands live in `CURL_TESTS.md`. Run `scripts/curl-tests.sh` to ca
 - `DELETE /api/portal/alert-recipients/{id}` – remove an alert email address
 - `GET /api/portal/daily-active` – daily active users and rate
 
+## ChatGPT Prompt
+
+When requesting French definitions, the backend sends the following instruction to GPT:
+
+```
+Vous \u00eates un assistant de dictionnaire.
+Fournis la d\u00e9finition de '<terme>' en fran\u00e7ais au format:
+D\u00e9finition: ...
+Synonymes: ...
+Les synonymes doivent \u00eatre s\u00e9par\u00e9s par des virgules.
+```
+
+This format ensures stable parsing of the returned text.
 
 ## 版本管理
 

--- a/src/main/java/com/glancy/backend/client/ChatGptClient.java
+++ b/src/main/java/com/glancy/backend/client/ChatGptClient.java
@@ -38,17 +38,37 @@ public class ChatGptClient {
 
         Map<String, Object> payload = new HashMap<>();
         payload.put("model", "gpt-3.5-turbo");
-        List<Map<String, String>> messages = List.of(
-                Map.of("role", "system", "content", "You are a dictionary assistant."),
-                Map.of(
-                        "role",
-                        "user",
-                        "content",
-                        "Define '" + term + "' in "
-                                + language.name().toLowerCase()
-                                + " and provide synonyms separated by comma."
-                )
-        );
+        List<Map<String, String>> messages;
+        if (language == Language.FRENCH) {
+            messages = List.of(
+                    Map.of(
+                            "role",
+                            "system",
+                            "content",
+                            "Vous êtes un assistant de dictionnaire."
+                    ),
+                    Map.of(
+                            "role",
+                            "user",
+                            "content",
+                            "Fournis la définition de '" + term + "' en français au format:\n" +
+                                    "Définition: ...\nSynonymes: ...\n" +
+                                    "Les synonymes doivent être séparés par des virgules."
+                    )
+            );
+        } else {
+            messages = List.of(
+                    Map.of("role", "system", "content", "You are a dictionary assistant."),
+                    Map.of(
+                            "role",
+                            "user",
+                            "content",
+                            "Define '" + term + "' in "
+                                    + language.name().toLowerCase()
+                                    + " and provide synonyms separated by comma."
+                    )
+            );
+        }
         payload.put("messages", messages);
 
         HttpEntity<Map<String, Object>> entity = new HttpEntity<>(payload, headers);


### PR DESCRIPTION
## Summary
- update `ChatGptClient` to use a French-specific prompt
- document the new prompt in `README.md`

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_6877d0f760b483329185afcb9baeae88