### PR TITLE
为西班牙语定制 GPT 提示

### DIFF
--- a/src/main/java/com/glancy/backend/client/ChatGptClient.java
+++ b/src/main/java/com/glancy/backend/client/ChatGptClient.java
@@ -38,17 +38,31 @@ public class ChatGptClient {
 
         Map<String, Object> payload = new HashMap<>();
         payload.put("model", "gpt-3.5-turbo");
-        List<Map<String, String>> messages = List.of(
-                Map.of("role", "system", "content", "You are a dictionary assistant."),
-                Map.of(
-                        "role",
-                        "user",
-                        "content",
-                        "Define '" + term + "' in "
-                                + language.name().toLowerCase()
-                                + " and provide synonyms separated by comma."
-                )
-        );
+        List<Map<String, String>> messages;
+        if (language == Language.SPANISH) {
+            messages = List.of(
+                    Map.of("role", "system", "content", "Eres un asistente de diccionario."),
+                    Map.of(
+                            "role",
+                            "user",
+                            "content",
+                            "Explica '" + term + "' en español. "
+                                    + "Responde con el formato:\nDefinición: <texto>\nSinónimos: <lista separada por comas>"
+                    )
+            );
+        } else {
+            messages = List.of(
+                    Map.of("role", "system", "content", "You are a dictionary assistant."),
+                    Map.of(
+                            "role",
+                            "user",
+                            "content",
+                            "Define '" + term + "' in "
+                                    + language.name().toLowerCase()
+                                    + " and provide synonyms separated by comma."
+                    )
+            );
+        }
         payload.put("messages", messages);
 
         HttpEntity<Map<String, Object>> entity = new HttpEntity<>(payload, headers);

--- a/src/main/java/com/glancy/backend/client/GoogleTtsClient.java
+++ b/src/main/java/com/glancy/backend/client/GoogleTtsClient.java
@@ -32,6 +32,7 @@ public class GoogleTtsClient {
         return switch (language) {
             case CHINESE -> "zh-CN";
             case ENGLISH -> "en";
+            case SPANISH -> "es";
             case JAPANESE -> "ja";
             case KOREAN -> "ko";
             case RUSSIAN -> "ru";

--- a/src/main/java/com/glancy/backend/entity/Language.java
+++ b/src/main/java/com/glancy/backend/entity/Language.java
@@ -6,6 +6,7 @@ package com.glancy.backend.entity;
 public enum Language {
     CHINESE,
     ENGLISH,
+    SPANISH,
     JAPANESE,
     KOREAN,
     RUSSIAN,

--- a/src/test/java/com/glancy/backend/client/ChatGptClientTest.java
+++ b/src/test/java/com/glancy/backend/client/ChatGptClientTest.java
@@ -1,0 +1,39 @@
+package com.glancy.backend.client;
+
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class ChatGptClientTest {
+    private MockRestServiceServer server;
+    private ChatGptClient client;
+
+    @BeforeEach
+    void setUp() {
+        RestTemplate restTemplate = new RestTemplate();
+        server = MockRestServiceServer.bindTo(restTemplate).build();
+        client = new ChatGptClient(restTemplate, "http://mock", "");
+    }
+
+    @Test
+    void spanishPromptIsUsed() {
+        server.expect(requestTo("http://mock/chat/completions"))
+                .andExpect(method(POST))
+                .andExpect(content().string(containsString("Explica 'hola' en español")))
+                .andRespond(withSuccess("{\"choices\":[{\"message\":{\"content\":\"ok\"}}]}", MediaType.APPLICATION_JSON));
+
+        WordResponse resp = client.fetchDefinition("hola", Language.SPANISH);
+        assertEquals("ok", resp.getDefinitions().get(0));
+        server.verify();
+    }
+}


### PR DESCRIPTION
## Summary
- 新增 `SPANISH` 枚举值
- 在 `ChatGptClient` 中对西班牙语使用专用提示语
- `GoogleTtsClient` 支持西班牙语代码
- 新增 `ChatGptClientTest` 单元测试

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_6877d0fbe128833286f01762326fe818