### PR TITLE
根据用户设置自动选择查词模型

### DIFF
--- a/scripts/curl-tests.sh
+++ b/scripts/curl-tests.sh
@@ -52,7 +52,7 @@ curl -i -H "Content-Type: application/json" \
 
 section "Save user preference"
 curl -i -H "Content-Type: application/json" \
-    -d '{"theme":"light","systemLanguage":"en","searchLanguage":"en"}' \
+    -d '{"theme":"light","systemLanguage":"en","searchLanguage":"en","dictionaryModel":"DEEPSEEK"}' \
     "$BASE_URL/api/preferences/user/1"
 
 section "Get user preference"

--- a/src/main/java/com/glancy/backend/controller/WordController.java
+++ b/src/main/java/com/glancy/backend/controller/WordController.java
@@ -34,15 +34,12 @@ public class WordController {
     @GetMapping
     public ResponseEntity<WordResponse> getWord(@RequestParam Long userId,
                                                 @RequestParam String term,
-                                                @RequestParam Language language,
-                                                @RequestParam(name = "gpt", required = false, defaultValue = "false") boolean gpt) {
+                                                @RequestParam Language language) {
         SearchRecordRequest req = new SearchRecordRequest();
         req.setTerm(term);
         req.setLanguage(language);
         searchRecordService.saveRecord(userId, req);
-        WordResponse resp = gpt ?
-                wordService.findWordWithGpt(term, language) :
-                wordService.findWordFromDeepSeek(term, language);
+        WordResponse resp = wordService.findWordForUser(userId, term, language);
         return ResponseEntity.ok(resp);
     }
 

--- a/src/main/java/com/glancy/backend/dto/UserPreferenceRequest.java
+++ b/src/main/java/com/glancy/backend/dto/UserPreferenceRequest.java
@@ -1,6 +1,8 @@
 package com.glancy.backend.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import com.glancy.backend.entity.DictionaryModel;
 import lombok.Data;
 
 /**
@@ -14,4 +16,7 @@ public class UserPreferenceRequest {
     private String systemLanguage;
     @NotBlank(message = "{validation.userPreference.searchLanguage.notblank}")
     private String searchLanguage;
+
+    @NotNull(message = "{validation.userPreference.dictionaryModel.notnull}")
+    private DictionaryModel dictionaryModel;
 }

--- a/src/main/java/com/glancy/backend/dto/UserPreferenceResponse.java
+++ b/src/main/java/com/glancy/backend/dto/UserPreferenceResponse.java
@@ -2,6 +2,7 @@ package com.glancy.backend.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import com.glancy.backend.entity.DictionaryModel;
 
 /**
  * DTO representing saved user preferences.
@@ -14,4 +15,5 @@ public class UserPreferenceResponse {
     private String theme;
     private String systemLanguage;
     private String searchLanguage;
+    private DictionaryModel dictionaryModel;
 }

--- a/src/main/java/com/glancy/backend/entity/DictionaryModel.java
+++ b/src/main/java/com/glancy/backend/entity/DictionaryModel.java
@@ -1,0 +1,10 @@
+package com.glancy.backend.entity;
+
+/**
+ * Supported dictionary models for word lookup.
+ */
+public enum DictionaryModel {
+    DEEPSEEK,
+    CHAT_GPT,
+    GEMINI
+}

--- a/src/main/java/com/glancy/backend/entity/UserPreference.java
+++ b/src/main/java/com/glancy/backend/entity/UserPreference.java
@@ -1,6 +1,7 @@
 package com.glancy.backend.entity;
 
 import jakarta.persistence.*;
+import com.glancy.backend.entity.DictionaryModel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -28,4 +29,8 @@ public class UserPreference {
 
     @Column(nullable = false, length = 20)
     private String searchLanguage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private DictionaryModel dictionaryModel = DictionaryModel.DEEPSEEK;
 }

--- a/src/main/java/com/glancy/backend/service/UserPreferenceService.java
+++ b/src/main/java/com/glancy/backend/service/UserPreferenceService.java
@@ -41,6 +41,7 @@ public class UserPreferenceService {
         pref.setTheme(req.getTheme());
         pref.setSystemLanguage(req.getSystemLanguage());
         pref.setSearchLanguage(req.getSearchLanguage());
+        pref.setDictionaryModel(req.getDictionaryModel());
         UserPreference saved = userPreferenceRepository.save(pref);
         return toResponse(saved);
     }
@@ -58,6 +59,7 @@ public class UserPreferenceService {
 
     private UserPreferenceResponse toResponse(UserPreference pref) {
         return new UserPreferenceResponse(pref.getId(), pref.getUser().getId(),
-                pref.getTheme(), pref.getSystemLanguage(), pref.getSearchLanguage());
+                pref.getTheme(), pref.getSystemLanguage(),
+                pref.getSearchLanguage(), pref.getDictionaryModel());
     }
 }

--- a/src/main/java/com/glancy/backend/service/dictionary/ChatGptStrategy.java
+++ b/src/main/java/com/glancy/backend/service/dictionary/ChatGptStrategy.java
@@ -1,0 +1,23 @@
+package com.glancy.backend.service.dictionary;
+
+import com.glancy.backend.client.ChatGptClient;
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+import org.springframework.stereotype.Component;
+
+/**
+ * Strategy using the ChatGPT API.
+ */
+@Component
+public class ChatGptStrategy implements DictionaryStrategy {
+    private final ChatGptClient chatGptClient;
+
+    public ChatGptStrategy(ChatGptClient chatGptClient) {
+        this.chatGptClient = chatGptClient;
+    }
+
+    @Override
+    public WordResponse fetch(String term, Language language) {
+        return chatGptClient.fetchDefinition(term, language);
+    }
+}

--- a/src/main/java/com/glancy/backend/service/dictionary/DeepSeekStrategy.java
+++ b/src/main/java/com/glancy/backend/service/dictionary/DeepSeekStrategy.java
@@ -1,0 +1,23 @@
+package com.glancy.backend.service.dictionary;
+
+import com.glancy.backend.client.DeepSeekClient;
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+import org.springframework.stereotype.Component;
+
+/**
+ * Strategy using the DeepSeek API.
+ */
+@Component
+public class DeepSeekStrategy implements DictionaryStrategy {
+    private final DeepSeekClient deepSeekClient;
+
+    public DeepSeekStrategy(DeepSeekClient deepSeekClient) {
+        this.deepSeekClient = deepSeekClient;
+    }
+
+    @Override
+    public WordResponse fetch(String term, Language language) {
+        return deepSeekClient.fetchDefinition(term, language);
+    }
+}

--- a/src/main/java/com/glancy/backend/service/dictionary/DictionaryStrategy.java
+++ b/src/main/java/com/glancy/backend/service/dictionary/DictionaryStrategy.java
@@ -1,0 +1,11 @@
+package com.glancy.backend.service.dictionary;
+
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+
+/**
+ * Strategy interface for dictionary lookups.
+ */
+public interface DictionaryStrategy {
+    WordResponse fetch(String term, Language language);
+}

--- a/src/main/java/com/glancy/backend/service/dictionary/GeminiStrategy.java
+++ b/src/main/java/com/glancy/backend/service/dictionary/GeminiStrategy.java
@@ -1,0 +1,23 @@
+package com.glancy.backend.service.dictionary;
+
+import com.glancy.backend.client.GeminiClient;
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+import org.springframework.stereotype.Component;
+
+/**
+ * Strategy using the Gemini API.
+ */
+@Component
+public class GeminiStrategy implements DictionaryStrategy {
+    private final GeminiClient geminiClient;
+
+    public GeminiStrategy(GeminiClient geminiClient) {
+        this.geminiClient = geminiClient;
+    }
+
+    @Override
+    public WordResponse fetch(String term, Language language) {
+        return geminiClient.fetchDefinition(term, language);
+    }
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -11,6 +11,7 @@ validation.thirdPartyAccount.externalId.notblank=External ID must not be blank
 validation.userPreference.theme.notblank=Theme must not be blank
 validation.userPreference.systemLanguage.notblank=System language must not be blank
 validation.userPreference.searchLanguage.notblank=Search language must not be blank
+validation.userPreference.dictionaryModel.notnull=Dictionary model must not be null
 validation.userRegistration.username.notblank=Username must not be blank
 validation.userRegistration.password.notblank=Password must not be blank
 validation.userRegistration.email.notblank=Email must not be blank

--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -12,6 +12,7 @@ validation.alertRecipient.email.notblank=Die E-Mail darf nicht leer sein
 validation.userPreference.theme.notblank=Das Thema darf nicht leer sein
 validation.userPreference.systemLanguage.notblank=Die Systemsprache darf nicht leer sein
 validation.userPreference.searchLanguage.notblank=Die Suchsprache darf nicht leer sein
+validation.userPreference.dictionaryModel.notnull=Das Wörterbuchmodell darf nicht null sein
 validation.userRegistration.username.notblank=Der Benutzername darf nicht leer sein
 validation.userRegistration.password.notblank=Das Passwort darf nicht leer sein
 validation.userRegistration.email.notblank=Die E-Mail darf nicht leer sein

--- a/src/main/resources/messages_fr.properties
+++ b/src/main/resources/messages_fr.properties
@@ -12,6 +12,7 @@ validation.alertRecipient.email.notblank=L'e-mail ne doit pas être vide
 validation.userPreference.theme.notblank=Le thème ne doit pas être vide
 validation.userPreference.systemLanguage.notblank=La langue du système ne doit pas être vide
 validation.userPreference.searchLanguage.notblank=La langue de recherche ne doit pas être vide
+validation.userPreference.dictionaryModel.notnull=Le modèle de dictionnaire ne doit pas être nul
 validation.userRegistration.username.notblank=Le nom d'utilisateur ne doit pas être vide
 validation.userRegistration.password.notblank=Le mot de passe ne doit pas être vide
 validation.userRegistration.email.notblank=L'e-mail ne doit pas être vide

--- a/src/main/resources/messages_ja.properties
+++ b/src/main/resources/messages_ja.properties
@@ -12,6 +12,7 @@ validation.alertRecipient.email.notblank=メールアドレスは空白にでき
 validation.userPreference.theme.notblank=テーマは空白にできません
 validation.userPreference.systemLanguage.notblank=システム言語は空白にできません
 validation.userPreference.searchLanguage.notblank=検索言語は空白にできません
+validation.userPreference.dictionaryModel.notnull=辞書モデルはnullにできません
 validation.userRegistration.username.notblank=ユーザー名は空白にできません
 validation.userRegistration.password.notblank=パスワードは空白にできません
 validation.userRegistration.email.notblank=メールアドレスは空白にできません

--- a/src/main/resources/messages_ko.properties
+++ b/src/main/resources/messages_ko.properties
@@ -12,6 +12,7 @@ validation.alertRecipient.email.notblank=이메일은 비워 둘 수 없습니�
 validation.userPreference.theme.notblank=테마는 비워 둘 수 없습니다
 validation.userPreference.systemLanguage.notblank=시스템 언어는 비워 둘 수 없습니다
 validation.userPreference.searchLanguage.notblank=검색 언어는 비워 둘 수 없습니다
+validation.userPreference.dictionaryModel.notnull=사전 모델은 null일 수 없습니다
 validation.userRegistration.username.notblank=사용자 이름은 비워 둘 수 없습니다
 validation.userRegistration.password.notblank=비밀번호는 비워 둘 수 없습니다
 validation.userRegistration.email.notblank=이메일은 비워 둘 수 없습니다

--- a/src/main/resources/messages_ru.properties
+++ b/src/main/resources/messages_ru.properties
@@ -12,6 +12,7 @@ validation.alertRecipient.email.notblank=Электронная почта не 
 validation.userPreference.theme.notblank=Тема не должна быть пустой
 validation.userPreference.systemLanguage.notblank=Язык системы не должен быть пустым
 validation.userPreference.searchLanguage.notblank=Язык поиска не должен быть пустым
+validation.userPreference.dictionaryModel.notnull=Модель словаря не может быть null
 validation.userRegistration.username.notblank=Имя пользователя не должно быть пустым
 validation.userRegistration.password.notblank=Пароль не должен быть пустым
 validation.userRegistration.email.notblank=Электронная почта не должна быть пустой

--- a/src/main/resources/messages_zh.properties
+++ b/src/main/resources/messages_zh.properties
@@ -11,6 +11,7 @@ validation.thirdPartyAccount.externalId.notblank=外部ID不能为空
 validation.userPreference.theme.notblank=主题不能为空
 validation.userPreference.systemLanguage.notblank=系统语言不能为空
 validation.userPreference.searchLanguage.notblank=搜索语言不能为空
+validation.userPreference.dictionaryModel.notnull=查词模型不能为空
 validation.userRegistration.username.notblank=用户名不能为空
 validation.userRegistration.password.notblank=密码不能为空
 validation.userRegistration.email.notblank=邮箱不能为空

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -104,6 +104,7 @@ CREATE TABLE IF NOT EXISTS user_preferences (
     theme VARCHAR(20) NOT NULL,
     systemLanguage VARCHAR(20) NOT NULL,
     searchLanguage VARCHAR(20) NOT NULL,
+    dictionaryModel VARCHAR(20) NOT NULL DEFAULT 'DEEPSEEK',
     CONSTRAINT fk_user_pref_user FOREIGN KEY (user_id) REFERENCES users(id)
 );
 

--- a/src/test/java/com/glancy/backend/controller/UserPreferenceControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/UserPreferenceControllerTest.java
@@ -5,6 +5,7 @@ import com.glancy.backend.dto.UserPreferenceRequest;
 import com.glancy.backend.dto.UserPreferenceResponse;
 import com.glancy.backend.service.AlertService;
 import com.glancy.backend.service.UserPreferenceService;
+import com.glancy.backend.entity.DictionaryModel;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -36,13 +37,14 @@ class UserPreferenceControllerTest {
 
     @Test
     void savePreference() throws Exception {
-        UserPreferenceResponse resp = new UserPreferenceResponse(1L, 2L, "dark", "en", "en");
+        UserPreferenceResponse resp = new UserPreferenceResponse(1L, 2L, "dark", "en", "en", DictionaryModel.DEEPSEEK);
         when(userPreferenceService.savePreference(eq(2L), any(UserPreferenceRequest.class))).thenReturn(resp);
 
         UserPreferenceRequest req = new UserPreferenceRequest();
         req.setTheme("dark");
         req.setSystemLanguage("en");
         req.setSearchLanguage("en");
+        req.setDictionaryModel(DictionaryModel.DEEPSEEK);
 
         mockMvc.perform(post("/api/preferences/user/2")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -53,7 +55,7 @@ class UserPreferenceControllerTest {
 
     @Test
     void getPreference() throws Exception {
-        UserPreferenceResponse resp = new UserPreferenceResponse(1L, 2L, "dark", "en", "en");
+        UserPreferenceResponse resp = new UserPreferenceResponse(1L, 2L, "dark", "en", "en", DictionaryModel.DEEPSEEK);
         when(userPreferenceService.getPreference(2L)).thenReturn(resp);
 
         mockMvc.perform(get("/api/preferences/user/2"))

--- a/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -35,7 +35,7 @@ class WordControllerTest {
     @Test
     void testGetWord() throws Exception {
         WordResponse resp = new WordResponse(1L, "hello", List.of("g"), Language.ENGLISH, "ex", "həˈloʊ");
-        when(wordService.findWordFromDeepSeek(eq("hello"), eq(Language.ENGLISH))).thenReturn(resp);
+        when(wordService.findWordForUser(eq(1L), eq("hello"), eq(Language.ENGLISH))).thenReturn(resp);
 
         mockMvc.perform(get("/api/words")
                         .param("userId", "1")

--- a/src/test/java/com/glancy/backend/service/UserPreferenceServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/UserPreferenceServiceTest.java
@@ -3,6 +3,7 @@ package com.glancy.backend.service;
 import com.glancy.backend.dto.UserPreferenceRequest;
 import com.glancy.backend.dto.UserPreferenceResponse;
 import com.glancy.backend.entity.User;
+import com.glancy.backend.entity.DictionaryModel;
 import com.glancy.backend.repository.UserPreferenceRepository;
 import com.glancy.backend.repository.UserRepository;
 
@@ -55,6 +56,7 @@ class UserPreferenceServiceTest {
         req.setTheme("light");
         req.setSystemLanguage("en");
         req.setSearchLanguage("zh");
+        req.setDictionaryModel(DictionaryModel.DEEPSEEK);
         UserPreferenceResponse saved = userPreferenceService.savePreference(user.getId(), req);
 
         assertNotNull(saved.getId());
@@ -63,5 +65,6 @@ class UserPreferenceServiceTest {
         UserPreferenceResponse fetched = userPreferenceService.getPreference(user.getId());
         assertEquals(saved.getId(), fetched.getId());
         assertEquals("zh", fetched.getSearchLanguage());
+        assertEquals(DictionaryModel.DEEPSEEK, fetched.getDictionaryModel());
     }
 }


### PR DESCRIPTION
## Summary
- 新增 `DictionaryModel` 枚举并在 `UserPreference` 中保存查词模型
- 新增多种查词策略并在 `WordService` 中根据用户设置选择
- 修改 `WordController` 使用新的服务方法
- 更新数据库 schema 及多语言校验消息
- 调整测试与 curl 脚本覆盖新字段

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_6877d0ed5d348332bb395975b9ca50e2