### PR TITLE
Improve language prompt handling

### DIFF
--- a/src/main/java/com/glancy/backend/client/prompt/DefaultPromptStrategy.java
+++ b/src/main/java/com/glancy/backend/client/prompt/DefaultPromptStrategy.java
@@ -1,0 +1,30 @@
+package com.glancy.backend.client.prompt;
+
+import com.glancy.backend.entity.Language;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Fallback prompt strategy used when no language-specific one matches.
+ */
+@Component
+@Order(Ordered.LOWEST_PRECEDENCE)
+public class DefaultPromptStrategy implements PromptStrategy {
+    @Override
+    public boolean supports(Language language) {
+        return true;
+    }
+
+    @Override
+    public List<Map<String, String>> buildMessages(String term, Language language) {
+        return List.of(
+            Map.of("role", "system", "content", "You are a dictionary assistant."),
+            Map.of("role", "user", "content",
+                "Define '" + term + "' in " + language.name().toLowerCase() +
+                " and provide synonyms separated by comma.")
+        );
+    }
+}

--- a/src/main/java/com/glancy/backend/client/prompt/FrenchPromptStrategy.java
+++ b/src/main/java/com/glancy/backend/client/prompt/FrenchPromptStrategy.java
@@ -1,0 +1,28 @@
+package com.glancy.backend.client.prompt;
+
+import com.glancy.backend.entity.Language;
+import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Prompt strategy for French definitions.
+ */
+@Component
+public class FrenchPromptStrategy implements PromptStrategy {
+    @Override
+    public boolean supports(Language language) {
+        return language == Language.FRENCH;
+    }
+
+    @Override
+    public List<Map<String, String>> buildMessages(String term, Language language) {
+        return List.of(
+            Map.of("role", "system", "content", "Vous êtes un assistant de dictionnaire."),
+            Map.of("role", "user", "content",
+                "Fournis la définition de '" + term + "' en français au format:\n" +
+                "Définition: ...\nSynonymes: ...\n" +
+                "Les synonymes doivent être séparés par des virgules.")
+        );
+    }
+}

--- a/src/main/java/com/glancy/backend/client/prompt/PromptStrategy.java
+++ b/src/main/java/com/glancy/backend/client/prompt/PromptStrategy.java
@@ -1,0 +1,20 @@
+package com.glancy.backend.client.prompt;
+
+import com.glancy.backend.entity.Language;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Strategy interface for building ChatGPT prompts.
+ */
+public interface PromptStrategy {
+    /**
+     * Whether this strategy supports the given language.
+     */
+    boolean supports(Language language);
+
+    /**
+     * Build the message list for the specified term and language.
+     */
+    List<Map<String, String>> buildMessages(String term, Language language);
+}

--- a/src/main/java/com/glancy/backend/client/prompt/SpanishPromptStrategy.java
+++ b/src/main/java/com/glancy/backend/client/prompt/SpanishPromptStrategy.java
@@ -1,0 +1,27 @@
+package com.glancy.backend.client.prompt;
+
+import com.glancy.backend.entity.Language;
+import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Prompt strategy for Spanish definitions.
+ */
+@Component
+public class SpanishPromptStrategy implements PromptStrategy {
+    @Override
+    public boolean supports(Language language) {
+        return language == Language.SPANISH;
+    }
+
+    @Override
+    public List<Map<String, String>> buildMessages(String term, Language language) {
+        return List.of(
+            Map.of("role", "system", "content", "Eres un asistente de diccionario."),
+            Map.of("role", "user", "content",
+                "Explica '" + term + "' en español. " +
+                "Responde con el formato:\nDefinición: <texto>\nSinónimos: <lista separada por comas>")
+        );
+    }
+}

--- a/src/test/java/com/glancy/backend/client/ChatGptClientTest.java
+++ b/src/test/java/com/glancy/backend/client/ChatGptClientTest.java
@@ -7,6 +7,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
+import java.util.List;
+import com.glancy.backend.client.prompt.DefaultPromptStrategy;
+import com.glancy.backend.client.prompt.SpanishPromptStrategy;
+import com.glancy.backend.client.prompt.FrenchPromptStrategy;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,7 +26,12 @@ class ChatGptClientTest {
     void setUp() {
         RestTemplate restTemplate = new RestTemplate();
         server = MockRestServiceServer.bindTo(restTemplate).build();
-        client = new ChatGptClient(restTemplate, "http://mock", "");
+        client = new ChatGptClient(restTemplate,
+                "http://mock",
+                "",
+                List.of(new SpanishPromptStrategy(),
+                        new FrenchPromptStrategy(),
+                        new DefaultPromptStrategy()));
     }
 
     @Test
@@ -30,9 +39,25 @@ class ChatGptClientTest {
         server.expect(requestTo("http://mock/chat/completions"))
                 .andExpect(method(POST))
                 .andExpect(content().string(containsString("Explica 'hola' en español")))
-                .andRespond(withSuccess("{\"choices\":[{\"message\":{\"content\":\"ok\"}}]}", MediaType.APPLICATION_JSON));
+                .andRespond(withSuccess(
+                        "{\"choices\":[{\"message\":{\"content\":\"ok\"}}]}",
+                        MediaType.APPLICATION_JSON));
 
         WordResponse resp = client.fetchDefinition("hola", Language.SPANISH);
+        assertEquals("ok", resp.getDefinitions().get(0));
+        server.verify();
+    }
+
+    @Test
+    void defaultPromptIsUsedForEnglish() {
+        server.expect(requestTo("http://mock/chat/completions"))
+                .andExpect(method(POST))
+                .andExpect(content().string(containsString("Define 'hello' in english")))
+                .andRespond(withSuccess(
+                        "{\"choices\":[{\"message\":{\"content\":\"ok\"}}]}",
+                        MediaType.APPLICATION_JSON));
+
+        WordResponse resp = client.fetchDefinition("hello", Language.ENGLISH);
         assertEquals("ok", resp.getDefinitions().get(0));
         server.verify();
     }


### PR DESCRIPTION
## Summary
- introduce `PromptStrategy` interface and several implementations
- refactor `ChatGptClient` to use prompt strategies
- update corresponding unit tests

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_6877d8a85a1883328d0c37e076bca0c0