### PR TITLE
[Feature] Add composite unique constraint for Word

### DIFF
--- a/src/main/java/com/glancy/backend/entity/Word.java
+++ b/src/main/java/com/glancy/backend/entity/Word.java
@@ -10,7 +10,8 @@ import java.util.List;
  * Dictionary word entry cached from the external service.
  */
 @Entity
-@Table(name = "words")
+@Table(name = "words",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"term", "language"}))
 @Data
 @NoArgsConstructor
 public class Word {
@@ -18,7 +19,7 @@ public class Word {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true, length = 100)
+    @Column(nullable = false, length = 100)
     private String term;
 
     @ElementCollection

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -32,12 +32,13 @@ CREATE TABLE IF NOT EXISTS search_records (
 
 CREATE TABLE IF NOT EXISTS words (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    term VARCHAR(100) NOT NULL UNIQUE,
+    term VARCHAR(100) NOT NULL,
     language VARCHAR(10) NOT NULL,
     phonetic VARCHAR(100),
     example VARCHAR(255),
     deleted BOOLEAN NOT NULL DEFAULT FALSE,
-    createdAt DATETIME NOT NULL
+    createdAt DATETIME NOT NULL,
+    CONSTRAINT uk_words_term_language UNIQUE (term, language)
 );
 
 CREATE TABLE IF NOT EXISTS word_definitions (

--- a/src/test/java/com/glancy/backend/service/WordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/WordServiceTest.java
@@ -179,4 +179,23 @@ class WordServiceTest {
         WordResponse result = wordService.findWordForUser(2L, "hi", Language.ENGLISH);
         assertEquals(resp, result);
     }
+
+    @Test
+    void testSaveSameTermDifferentLanguage() {
+        Word wordEn = new Word();
+        wordEn.setTerm("hello");
+        wordEn.setLanguage(Language.ENGLISH);
+        wordEn.setDefinitions(List.of("greet"));
+        wordRepository.save(wordEn);
+
+        Word wordEs = new Word();
+        wordEs.setTerm("hello");
+        wordEs.setLanguage(Language.SPANISH);
+        wordEs.setDefinitions(List.of("hola"));
+
+        assertDoesNotThrow(() -> wordRepository.save(wordEs));
+
+        assertTrue(wordRepository.findByTermAndLanguageAndDeletedFalse("hello", Language.ENGLISH).isPresent());
+        assertTrue(wordRepository.findByTermAndLanguageAndDeletedFalse("hello", Language.SPANISH).isPresent());
+    }
 }


### PR DESCRIPTION
## Summary
- enforce uniqueness by `(term, language)` in `Word` entity
- update the database schema with a composite unique index
- allow saving same term for different languages via new test

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_68789cc1d2cc8332ac308d16e8dd5fe1