### PR TITLE
[Refactor] Remove unused getAudioFromDeepSeek method

### DIFF
--- a/src/main/java/com/glancy/backend/service/WordService.java
+++ b/src/main/java/com/glancy/backend/service/WordService.java
@@ -137,12 +137,6 @@ public class WordService {
         return strategy.fetch(term, language);
     }
 
-    @Transactional(readOnly = true)
-    public byte[] getAudioFromDeepSeek(String term, Language language) {
-        log.info("Fetching audio for term '{}' in language {}", term, language);
-        return deepSeekClient.fetchAudio(term, language);
-    }
-
     private void saveWord(WordResponse resp) {
         Word word = new Word();
         word.setTerm(resp.getTerm());


### PR DESCRIPTION
## Summary
- delete the unused `getAudioFromDeepSeek` method in `WordService`

## Testing
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_68789cc22c2883329ca3f03f98b35258