### PR TITLE
[Feature] Toggle version-based deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      VERSION_CHECK_ENABLED: "false"
 
     steps:
       - name: Checkout Code
@@ -16,14 +18,23 @@ jobs:
       - name: 判定是否需要部署
         id: version_check
         run: |
-          current_version=$(grep -A1 '<artifactId>glancy-backend</artifactId>' pom.xml | grep '<version>' | sed -E 's/.*<version>(.*)<\/version>.*/\1/')
-          previous_version=$(git show HEAD~1:pom.xml | grep -A1 '<artifactId>glancy-backend</artifactId>' | grep '<version>' | sed -E 's/.*<version>(.*)<\/version>.*/\1/' || echo '')
-          curr_minor=$(echo "$current_version" | cut -d. -f2)
-          prev_minor=$(echo "$previous_version" | cut -d. -f2)
-          if [ "$curr_minor" != "$prev_minor" ]; then
-            echo "deploy=true" >> $GITHUB_OUTPUT
+          current_version=$(grep -A1 '<artifactId>glancy-backend</artifactId>' pom.xml \
+            | grep '<version>' \
+            | sed -E 's/.*<version>(.*)<\/version>.*/\1/')
+          if [ "$VERSION_CHECK_ENABLED" = "true" ]; then
+            previous_version=$(git show HEAD~1:pom.xml \
+              | grep -A1 '<artifactId>glancy-backend</artifactId>' \
+              | grep '<version>' \
+              | sed -E 's/.*<version>(.*)<\/version>.*/\1/' || echo '')
+            curr_minor=$(echo "$current_version" | cut -d. -f2)
+            prev_minor=$(echo "$previous_version" | cut -d. -f2)
+            if [ "$curr_minor" != "$prev_minor" ]; then
+              echo "deploy=true" >> $GITHUB_OUTPUT
+            else
+              echo "deploy=false" >> $GITHUB_OUTPUT
+            fi
           else
-            echo "deploy=false" >> $GITHUB_OUTPUT
+            echo "deploy=true" >> $GITHUB_OUTPUT
           fi
           echo "version=$current_version" >> $GITHUB_OUTPUT
 

--- a/README.md
+++ b/README.md
@@ -120,3 +120,6 @@ This format ensures stable parsing of the returned text.
 
 项目版本号定义在 `pom.xml` 中。默认合并时只递增补丁版本号。若提升中版本号，请在 PR 中说明，GitHub Actions 会在检测到中版本号变更时自动部署。
 
+部署工作流包含变量 `VERSION_CHECK_ENABLED`，默认值为 `false`。当设置为 `true` 时，
+只有中版本号变化才会触发部署；否则始终部署。
+


### PR DESCRIPTION
## Summary
- add VERSION_CHECK_ENABLED flag to deploy workflow
- document deployment flag in README

## Testing
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_68790c6e4ffc8332832367dd4627bfcf