### PR TITLE
[Feature] Add global CORS configuration

### DIFF
--- a/src/main/java/com/glancy/backend/config/SecurityConfig.java
+++ b/src/main/java/com/glancy/backend/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.config.Customizer;
 
 @Configuration
 public class SecurityConfig {
@@ -14,6 +15,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+            .cors(Customizer.withDefaults())
             .csrf(csrf -> csrf.disable())
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/portal/**", "/api/notifications/system").authenticated()

--- a/src/main/java/com/glancy/backend/config/WebConfig.java
+++ b/src/main/java/com/glancy/backend/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.glancy.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+            .allowedOrigins("*")
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
+    }
+}


### PR DESCRIPTION
## Summary
- create `WebConfig` implementing `WebMvcConfigurer` to allow CORS for `/api/**`
- enable CORS in `SecurityConfig`

## Testing
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_687a417b3494833295f74343b4ce98f0