### PR TITLE
[Fix] annotate CorsRegistry param with NonNull

### DIFF
--- a/src/main/java/com/glancy/backend/config/WebConfig.java
+++ b/src/main/java/com/glancy/backend/config/WebConfig.java
@@ -3,12 +3,13 @@ package com.glancy.backend.config;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.lang.NonNull;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
     @Override
-    public void addCorsMappings(CorsRegistry registry) {
+    public void addCorsMappings(@NonNull CorsRegistry registry) {
         registry.addMapping("/api/**")
             .allowedOrigins("*")
             .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");


### PR DESCRIPTION
## Summary
- annotate `CorsRegistry` parameter with `@NonNull` in `WebConfig`

## Testing
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_687a4c6bc65083329c6fdd6cbc20d044