### PR TITLE
[Refactor] Replace deprecated MockBean usage

### DIFF
--- a/src/test/java/com/glancy/backend/controller/AlertRecipientControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/AlertRecipientControllerTest.java
@@ -8,7 +8,7 @@ import com.glancy.backend.service.AlertService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.context.annotation.Import;
@@ -26,13 +26,13 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 @WebMvcTest(AlertRecipientController.class)
 @Import(com.glancy.backend.config.SecurityConfig.class)
 class AlertRecipientControllerTest {
-    @MockBean
+    @MockitoBean
     private AlertService alertService;
 
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private AlertRecipientService alertRecipientService;
 
     @Autowired

--- a/src/test/java/com/glancy/backend/controller/ContactControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/ContactControllerTest.java
@@ -8,7 +8,7 @@ import com.glancy.backend.service.ContactService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.context.annotation.Import;
@@ -22,13 +22,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(com.glancy.backend.config.SecurityConfig.class)
 class ContactControllerTest {
 
-    @MockBean
+    @MockitoBean
     private AlertService alertService;
 
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private ContactService contactService;
 
     @Autowired

--- a/src/test/java/com/glancy/backend/controller/FaqControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/FaqControllerTest.java
@@ -8,7 +8,7 @@ import com.glancy.backend.service.FaqService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.context.annotation.Import;
@@ -24,13 +24,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(com.glancy.backend.config.SecurityConfig.class)
 class FaqControllerTest {
 
-    @MockBean
+    @MockitoBean
     private AlertService alertService;
 
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private FaqService faqService;
 
     @Autowired

--- a/src/test/java/com/glancy/backend/controller/NotificationControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/NotificationControllerTest.java
@@ -8,7 +8,7 @@ import com.glancy.backend.service.NotificationService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.context.annotation.Import;
@@ -25,13 +25,13 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 @WebMvcTest(NotificationController.class)
 @Import(com.glancy.backend.config.SecurityConfig.class)
 class NotificationControllerTest {
-    @MockBean
+    @MockitoBean
     private AlertService alertService;
     
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private NotificationService notificationService;
 
     @Autowired

--- a/src/test/java/com/glancy/backend/controller/PingControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/PingControllerTest.java
@@ -3,7 +3,7 @@ package com.glancy.backend.controller;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.context.annotation.Import;
 import com.glancy.backend.service.AlertService;
@@ -15,7 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(PingController.class)
 @Import(com.glancy.backend.config.SecurityConfig.class)
 class PingControllerTest {
-    @MockBean
+    @MockitoBean
     private AlertService alertService;
 
     @Autowired

--- a/src/test/java/com/glancy/backend/controller/PortalControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/PortalControllerTest.java
@@ -13,7 +13,7 @@ import com.glancy.backend.service.SystemParameterService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -30,18 +30,18 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 @WebMvcTest(PortalController.class)
 @Import(com.glancy.backend.config.SecurityConfig.class)
 class PortalControllerTest {
-    @MockBean
+    @MockitoBean
     private AlertService alertService;
     
-    @MockBean
+    @MockitoBean
     private LoggingService loggingService;
 
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private SystemParameterService parameterService;
-    @MockBean
+    @MockitoBean
     private UserService userService;
 
     @Autowired

--- a/src/test/java/com/glancy/backend/controller/PortalTrafficControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/PortalTrafficControllerTest.java
@@ -8,7 +8,7 @@ import com.glancy.backend.service.TrafficRecordService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.context.annotation.Import;
@@ -26,13 +26,13 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 @WebMvcTest(PortalTrafficController.class)
 @Import(com.glancy.backend.config.SecurityConfig.class)
 class PortalTrafficControllerTest {
-    @MockBean
+    @MockitoBean
     private AlertService alertService;
     
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private TrafficRecordService trafficRecordService;
 
     @Autowired

--- a/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
@@ -9,7 +9,7 @@ import com.glancy.backend.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.context.annotation.Import;
@@ -26,14 +26,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(SearchRecordController.class)
 @Import(com.glancy.backend.config.SecurityConfig.class)
 class SearchRecordControllerTest {
-    @MockBean
+    @MockitoBean
     private AlertService alertService;
     
     @Autowired
     private MockMvc mockMvc;
-    @MockBean
+    @MockitoBean
     private SearchRecordService searchRecordService;
-    @MockBean
+    @MockitoBean
     private UserService userService;
 
     @Test

--- a/src/test/java/com/glancy/backend/controller/UserControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/UserControllerTest.java
@@ -8,7 +8,7 @@ import com.glancy.backend.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.context.annotation.Import;
@@ -23,13 +23,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(UserController.class)
 @Import(com.glancy.backend.config.SecurityConfig.class)
 class UserControllerTest {
-    @MockBean
+    @MockitoBean
     private AlertService alertService;
 
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private UserService userService;
 
     @Autowired

--- a/src/test/java/com/glancy/backend/controller/UserPreferenceControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/UserPreferenceControllerTest.java
@@ -9,7 +9,7 @@ import com.glancy.backend.entity.DictionaryModel;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.context.annotation.Import;
@@ -23,13 +23,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(UserPreferenceController.class)
 @Import(com.glancy.backend.config.SecurityConfig.class)
 class UserPreferenceControllerTest {
-    @MockBean
+    @MockitoBean
     private AlertService alertService;
     
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private UserPreferenceService userPreferenceService;
 
     @Autowired

--- a/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -9,7 +9,7 @@ import com.glancy.backend.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.context.annotation.Import;
@@ -27,13 +27,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class WordControllerTest {
     @Autowired
     private MockMvc mockMvc;
-    @MockBean
+    @MockitoBean
     private WordService wordService;
-    @MockBean
+    @MockitoBean
     private SearchRecordService searchRecordService;
-    @MockBean
+    @MockitoBean
     private AlertService alertService;
-    @MockBean
+    @MockitoBean
     private UserService userService;
 
     @Test

--- a/src/test/java/com/glancy/backend/service/AlertServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/AlertServiceTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +28,7 @@ class AlertServiceTest {
     @Autowired
     private SystemParameterRepository parameterRepository;
 
-    @MockBean
+    @MockitoBean
     private JavaMailSender mailSender;
 
     @BeforeAll

--- a/src/test/java/com/glancy/backend/service/LoggingServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/LoggingServiceTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.boot.logging.LogLevel;
 import org.springframework.boot.logging.LoggingSystem;
 
@@ -17,7 +17,7 @@ class LoggingServiceTest {
     @Autowired
     private LoggingService loggingService;
 
-    @MockBean
+    @MockitoBean
     private LoggingSystem loggingSystem;
 
     @BeforeAll

--- a/src/test/java/com/glancy/backend/service/WordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/WordServiceTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -35,25 +35,25 @@ import static org.mockito.Mockito.*;
 class WordServiceTest {
     @Autowired
     private WordService wordService;
-    @MockBean
+    @MockitoBean
     private DeepSeekClient deepSeekClient;
-    @MockBean
+    @MockitoBean
     private ChatGptClient chatGptClient;
-    @MockBean
+    @MockitoBean
     private GoogleTtsClient googleTtsClient;
-    @MockBean
+    @MockitoBean
     private GeminiClient geminiClient;
-    @MockBean
+    @MockitoBean
     private QianWenClient qianWenClient;
-    @MockBean
+    @MockitoBean
     private UserPreferenceRepository userPreferenceRepository;
-    @MockBean
+    @MockitoBean
     private DeepSeekStrategy deepSeekStrategy;
-    @MockBean
+    @MockitoBean
     private ChatGptStrategy chatGptStrategy;
-    @MockBean
+    @MockitoBean
     private GeminiStrategy geminiStrategy;
-    @MockBean
+    @MockitoBean
     private QianWenStrategy qianWenStrategy;
     @Autowired
     private WordRepository wordRepository;


### PR DESCRIPTION
## Summary
- switch from `@MockBean` to the new `@MockitoBean` annotation in tests

## Testing
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_687a4c52a71483328754c70a56e9a00f