### PR TITLE
[Fix] Replace deprecated fromHttpUrl calls

### DIFF
--- a/src/main/java/com/glancy/backend/client/DeepSeekClient.java
+++ b/src/main/java/com/glancy/backend/client/DeepSeekClient.java
@@ -26,7 +26,7 @@ public class DeepSeekClient {
     }
 
     public WordResponse fetchDefinition(String term, Language language) {
-        String url = UriComponentsBuilder.fromHttpUrl(baseUrl)
+        String url = UriComponentsBuilder.fromUriString(baseUrl)
                 .path("/words/definition")
                 .queryParam("term", term)
                 .queryParam("language", language.name().toLowerCase())
@@ -46,7 +46,7 @@ public class DeepSeekClient {
     }
 
     public byte[] fetchAudio(String term, Language language) {
-        String url = UriComponentsBuilder.fromHttpUrl(baseUrl)
+        String url = UriComponentsBuilder.fromUriString(baseUrl)
                 .path("/words/audio")
                 .queryParam("term", term)
                 .queryParam("language", language.name().toLowerCase())

--- a/src/main/java/com/glancy/backend/client/GeminiClient.java
+++ b/src/main/java/com/glancy/backend/client/GeminiClient.java
@@ -25,7 +25,7 @@ public class GeminiClient {
      * Fetch word definition from Gemini.
      */
     public WordResponse fetchDefinition(String term, Language language) {
-        String url = UriComponentsBuilder.fromHttpUrl(baseUrl)
+        String url = UriComponentsBuilder.fromUriString(baseUrl)
                 .path("/words/definition")
                 .queryParam("term", term)
                 .queryParam("language", language.name().toLowerCase())

--- a/src/main/java/com/glancy/backend/client/GoogleTtsClient.java
+++ b/src/main/java/com/glancy/backend/client/GoogleTtsClient.java
@@ -18,7 +18,7 @@ public class GoogleTtsClient {
     }
 
     public byte[] fetchPronunciation(String term, Language language) {
-        String url = UriComponentsBuilder.fromHttpUrl(baseUrl)
+        String url = UriComponentsBuilder.fromUriString(baseUrl)
                 .path("/translate_tts")
                 .queryParam("ie", "UTF-8")
                 .queryParam("client", "tw-ob")

--- a/src/main/java/com/glancy/backend/client/QianWenClient.java
+++ b/src/main/java/com/glancy/backend/client/QianWenClient.java
@@ -22,7 +22,7 @@ public class QianWenClient {
     }
 
     public WordResponse fetchDefinition(String term, Language language) {
-        String url = UriComponentsBuilder.fromHttpUrl(baseUrl)
+        String url = UriComponentsBuilder.fromUriString(baseUrl)
                 .path("/words/definition")
                 .queryParam("term", term)
                 .queryParam("language", language.name().toLowerCase())


### PR DESCRIPTION
## Summary
- use `fromUriString` instead of deprecated `fromHttpUrl`

## Testing
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_687a4f4b97dc8332a294cdd45118944f