### PR TITLE
[Fix] Load model API keys from .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Glancy Backend is a Spring Boot service that powers the Glancy dictionary applic
 ## Setup
 
 1. Clone this repository.
-2. Provide a `DB_PASSWORD` value via a `.env` file or environment variable.
+2. Create a `.env` file with `DB_PASSWORD`, `thirdparty.deepseek.api-key` and
+   `thirdparty.openai.api-key` values.
 3. Ensure MySQL is running with a database named `glancy_db`, matching credentials, and SSL certificates configured as `useSSL=true` requires.
 4. Use the `local` Spring profile if SSL is unavailable: `./mvnw spring-boot:run -Dspring.profiles.active=local`.
 5. Configure optional API base URLs in `application.yml` under the `thirdparty` section.

--- a/src/main/java/com/glancy/backend/GlancyBackendApplication.java
+++ b/src/main/java/com/glancy/backend/GlancyBackendApplication.java
@@ -23,9 +23,13 @@ public class GlancyBackendApplication {
         if (dbPassword != null) {
             System.setProperty("DB_PASSWORD", dbPassword);
         }
-        String apiKey = dotenv.get("thirdparty.deepseek.api-key");
-        if (apiKey != null) {
-            System.setProperty("thirdparty.deepseek.api-key", apiKey);
+        String deepseekKey = dotenv.get("thirdparty.deepseek.api-key");
+        if (deepseekKey != null) {
+            System.setProperty("thirdparty.deepseek.api-key", deepseekKey);
+        }
+        String openaiKey = dotenv.get("thirdparty.openai.api-key");
+        if (openaiKey != null) {
+            System.setProperty("thirdparty.openai.api-key", openaiKey);
         }
         SpringApplication.run(GlancyBackendApplication.class, args);
     }


### PR DESCRIPTION
## Summary
- load `thirdparty.openai.api-key` from `.env`
- document required `.env` variables

## Testing
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_687a5171b03883329a1ede3320ddd2e4