### PR TITLE
[Feature] Add tests for API clients

### DIFF
--- a/src/test/java/com/glancy/backend/client/DeepSeekClientTest.java
+++ b/src/test/java/com/glancy/backend/client/DeepSeekClientTest.java
@@ -1,0 +1,53 @@
+package com.glancy.backend.client;
+
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class DeepSeekClientTest {
+    private MockRestServiceServer server;
+    private DeepSeekClient client;
+
+    @BeforeEach
+    void setUp() {
+        RestTemplate restTemplate = new RestTemplate();
+        server = MockRestServiceServer.bindTo(restTemplate).build();
+        client = new DeepSeekClient(restTemplate, "http://mock", "key");
+    }
+
+    @Test
+    void fetchDefinitionWithAuth() {
+        String json = "{\"id\":null,\"term\":\"hello\",\"definitions\":[\"hi\"],\"language\":\"ENGLISH\",\"example\":null,\"phonetic\":null}";
+        server.expect(requestTo("http://mock/words/definition?term=hello&language=english"))
+                .andExpect(method(GET))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer key"))
+                .andRespond(withSuccess(json, MediaType.APPLICATION_JSON));
+
+        WordResponse resp = client.fetchDefinition("hello", Language.ENGLISH);
+        assertEquals("hi", resp.getDefinitions().get(0));
+        server.verify();
+    }
+
+    @Test
+    void fetchAudioWithAuth() {
+        byte[] audio = new byte[] {1};
+        server.expect(requestTo("http://mock/words/audio?term=hello&language=english"))
+                .andExpect(method(GET))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer key"))
+                .andRespond(withSuccess(audio, MediaType.APPLICATION_OCTET_STREAM));
+
+        byte[] resp = client.fetchAudio("hello", Language.ENGLISH);
+        assertArrayEquals(audio, resp);
+        server.verify();
+    }
+}

--- a/src/test/java/com/glancy/backend/client/GeminiClientTest.java
+++ b/src/test/java/com/glancy/backend/client/GeminiClientTest.java
@@ -1,0 +1,38 @@
+package com.glancy.backend.client;
+
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class GeminiClientTest {
+    private MockRestServiceServer server;
+    private GeminiClient client;
+
+    @BeforeEach
+    void setUp() {
+        RestTemplate restTemplate = new RestTemplate();
+        server = MockRestServiceServer.bindTo(restTemplate).build();
+        client = new GeminiClient(restTemplate, "http://mock");
+    }
+
+    @Test
+    void fetchDefinition() {
+        String json = "{\"id\":null,\"term\":\"hola\",\"definitions\":[\"hi\"],\"language\":\"SPANISH\",\"example\":null,\"phonetic\":null}";
+        server.expect(requestTo("http://mock/words/definition?term=hola&language=spanish"))
+                .andExpect(method(GET))
+                .andRespond(withSuccess(json, MediaType.APPLICATION_JSON));
+
+        WordResponse resp = client.fetchDefinition("hola", Language.SPANISH);
+        assertEquals("hi", resp.getDefinitions().get(0));
+        server.verify();
+    }
+}

--- a/src/test/java/com/glancy/backend/client/GoogleTtsClientTest.java
+++ b/src/test/java/com/glancy/backend/client/GoogleTtsClientTest.java
@@ -1,0 +1,49 @@
+package com.glancy.backend.client;
+
+import com.glancy.backend.entity.Language;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class GoogleTtsClientTest {
+    private MockRestServiceServer server;
+    private GoogleTtsClient client;
+
+    @BeforeEach
+    void setUp() {
+        RestTemplate restTemplate = new RestTemplate();
+        server = MockRestServiceServer.bindTo(restTemplate).build();
+        client = new GoogleTtsClient(restTemplate, "http://mock");
+    }
+
+    @Test
+    void fetchPronunciationEnglish() {
+        byte[] audio = new byte[] {1, 2};
+        server.expect(requestTo("http://mock/translate_tts?ie=UTF-8&client=tw-ob&tl=en&q=hello"))
+                .andExpect(method(GET))
+                .andRespond(withSuccess(audio, MediaType.APPLICATION_OCTET_STREAM));
+
+        byte[] resp = client.fetchPronunciation("hello", Language.ENGLISH);
+        assertArrayEquals(audio, resp);
+        server.verify();
+    }
+
+    @Test
+    void fetchPronunciationChinese() {
+        byte[] audio = new byte[] {3, 4};
+        server.expect(requestTo("http://mock/translate_tts?ie=UTF-8&client=tw-ob&tl=zh-CN&q=nihao"))
+                .andExpect(method(GET))
+                .andRespond(withSuccess(audio, MediaType.APPLICATION_OCTET_STREAM));
+
+        byte[] resp = client.fetchPronunciation("nihao", Language.CHINESE);
+        assertArrayEquals(audio, resp);
+        server.verify();
+    }
+}

--- a/src/test/java/com/glancy/backend/client/QianWenClientTest.java
+++ b/src/test/java/com/glancy/backend/client/QianWenClientTest.java
@@ -1,0 +1,38 @@
+package com.glancy.backend.client;
+
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class QianWenClientTest {
+    private MockRestServiceServer server;
+    private QianWenClient client;
+
+    @BeforeEach
+    void setUp() {
+        RestTemplate restTemplate = new RestTemplate();
+        server = MockRestServiceServer.bindTo(restTemplate).build();
+        client = new QianWenClient(restTemplate, "http://mock");
+    }
+
+    @Test
+    void fetchDefinition() {
+        String json = "{\"id\":null,\"term\":\"salut\",\"definitions\":[\"hello\"],\"language\":\"FRENCH\",\"example\":null,\"phonetic\":null}";
+        server.expect(requestTo("http://mock/words/definition?term=salut&language=french"))
+                .andExpect(method(GET))
+                .andRespond(withSuccess(json, MediaType.APPLICATION_JSON));
+
+        WordResponse resp = client.fetchDefinition("salut", Language.FRENCH);
+        assertEquals("hello", resp.getDefinitions().get(0));
+        server.verify();
+    }
+}


### PR DESCRIPTION
## Summary
- add `GeminiClientTest`, `GoogleTtsClientTest`, `DeepSeekClientTest` and `QianWenClientTest`

## Testing
- `./mvnw test -DskipITs`

------
https://chatgpt.com/codex/tasks/task_e_687a52473498833288a7f05e14e51fcd