### PR TITLE
[Test] Add disabled DeepSeek API example

### DIFF
--- a/src/test/java/com/glancy/backend/client/DeepSeekClientTest.java
+++ b/src/test/java/com/glancy/backend/client/DeepSeekClientTest.java
@@ -2,7 +2,9 @@ package com.glancy.backend.client;
 
 import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.Language;
+import io.github.cdimascio.dotenv.Dotenv;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -49,5 +51,26 @@ class DeepSeekClientTest {
         byte[] resp = client.fetchAudio("hello", Language.ENGLISH);
         assertArrayEquals(audio, resp);
         server.verify();
+    }
+
+    @Disabled("Requires network access to DeepSeek API")
+    @Test
+    void callDeepSeekApiExample() {
+        Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+        String key = dotenv.get("thirdparty.deepseek.api-key");
+        RestTemplate rt = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        if (key != null && !key.isEmpty()) {
+            headers.setBearerAuth(key);
+        }
+
+        String body = """
+            {"model":"deepseek-chat","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"介绍一下牛顿第一定律"}],"temperature":0.7,"stream":true}
+            """;
+        var entity = new org.springframework.http.HttpEntity<>(body, headers);
+        var response = rt.postForEntity("https://api.deepseek.com/v1/chat/completions", entity, String.class);
+        System.out.println(response.getBody());
     }
 }


### PR DESCRIPTION
## Summary
- add a sample test that shows how to call DeepSeek API
- mark it disabled since the environment cannot access the real service

## Testing
- `./mvnw test -q`


------
https://chatgpt.com/codex/tasks/task_e_687a5bbe12188332a1d2f25e4c4a09bf