### PR TITLE
[Feature] Add avatar upload via OSS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 	<properties>
 		<java.version>17</java.version>
 	</properties>
-	<dependencies>
+        <dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -81,12 +81,17 @@
 			<version>3.0.0</version>
 		</dependency>
 		<!-- H2 In‑Memory Database for Tests -->
-		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.aliyun.oss</groupId>
+                        <artifactId>aliyun-sdk-oss</artifactId>
+                        <version>3.18.2</version>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/glancy/backend/GlancyBackendApplication.java
+++ b/src/main/java/com/glancy/backend/GlancyBackendApplication.java
@@ -27,6 +27,14 @@ public class GlancyBackendApplication {
         if (deepseekKey != null) {
             System.setProperty("thirdparty.deepseek.api-key", deepseekKey);
         }
+        String ossKey = dotenv.get("OSS_ACCESS_KEY_ID");
+        if (ossKey != null) {
+            System.setProperty("OSS_ACCESS_KEY_ID", ossKey);
+        }
+        String ossSecret = dotenv.get("OSS_ACCESS_KEY_SECRET");
+        if (ossSecret != null) {
+            System.setProperty("OSS_ACCESS_KEY_SECRET", ossSecret);
+        }
         SpringApplication.run(GlancyBackendApplication.class, args);
     }
 

--- a/src/main/java/com/glancy/backend/controller/UserController.java
+++ b/src/main/java/com/glancy/backend/controller/UserController.java
@@ -15,6 +15,7 @@ import com.glancy.backend.dto.AvatarRequest;
 import com.glancy.backend.dto.AvatarResponse;
 import com.glancy.backend.dto.UsernameRequest;
 import com.glancy.backend.dto.UsernameResponse;
+import org.springframework.web.multipart.MultipartFile;
 import com.glancy.backend.entity.User;
 import com.glancy.backend.service.UserService;
 
@@ -96,6 +97,17 @@ public class UserController {
             @PathVariable Long id,
             @Valid @RequestBody AvatarRequest req) {
         AvatarResponse resp = userService.updateAvatar(id, req.getAvatar());
+        return ResponseEntity.ok(resp);
+    }
+
+    /**
+     * Upload avatar file to OSS and update user record.
+     */
+    @PostMapping("/{id}/avatar-file")
+    public ResponseEntity<AvatarResponse> uploadAvatar(
+            @PathVariable Long id,
+            @RequestParam("file") MultipartFile file) {
+        AvatarResponse resp = userService.uploadAvatar(id, file);
         return ResponseEntity.ok(resp);
     }
 

--- a/src/main/java/com/glancy/backend/service/AvatarStorageService.java
+++ b/src/main/java/com/glancy/backend/service/AvatarStorageService.java
@@ -1,0 +1,73 @@
+package com.glancy.backend.service;
+
+import com.aliyun.oss.OSS;
+import com.aliyun.oss.OSSClientBuilder;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Handles uploading avatar images to Alibaba Cloud OSS.
+ */
+@Service
+public class AvatarStorageService {
+    private final String endpoint;
+    private final String bucket;
+    private final String accessKeyId;
+    private final String accessKeySecret;
+    private final String avatarDir;
+    private final String urlPrefix;
+
+    private OSS ossClient;
+
+    public AvatarStorageService(
+            @Value("${oss.endpoint}") String endpoint,
+            @Value("${oss.bucket}") String bucket,
+            @Value("${oss.access-key-id:}") String accessKeyId,
+            @Value("${oss.access-key-secret:}") String accessKeySecret,
+            @Value("${oss.avatar-dir:avatars/}") String avatarDir) {
+        this.endpoint = endpoint;
+        this.bucket = bucket;
+        this.accessKeyId = accessKeyId;
+        this.accessKeySecret = accessKeySecret;
+        this.avatarDir = avatarDir;
+        this.urlPrefix = String.format("https://%s.%s/", bucket, endpoint.replaceFirst("https?://", ""));
+    }
+
+    @PostConstruct
+    public void init() {
+        if (accessKeyId != null && !accessKeyId.isEmpty()
+                && accessKeySecret != null && !accessKeySecret.isEmpty()) {
+            this.ossClient = new OSSClientBuilder().build(endpoint, accessKeyId, accessKeySecret);
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        if (ossClient != null) {
+            ossClient.shutdown();
+        }
+    }
+
+    /**
+     * Upload the avatar and return the public URL.
+     */
+    public String upload(MultipartFile file) throws IOException {
+        if (ossClient == null) {
+            throw new IllegalStateException("OSS client not configured");
+        }
+        String original = file.getOriginalFilename();
+        String ext = "";
+        if (original != null && original.contains(".")) {
+            ext = original.substring(original.lastIndexOf('.'));
+        }
+        String objectName = avatarDir + UUID.randomUUID() + ext;
+        ossClient.putObject(bucket, objectName, file.getInputStream());
+        return urlPrefix + objectName;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,3 +44,10 @@ portal:
     admin-token: secret
     qianwen:
         base-url: https://api.qianwen.com
+
+oss:
+    endpoint: https://oss-cn-hangzhou.aliyuncs.com
+    bucket: glancy-avatar-bucket
+    avatar-dir: avatars/
+    access-key-id: ${OSS_ACCESS_KEY_ID:}
+    access-key-secret: ${OSS_ACCESS_KEY_SECRET:}

--- a/src/test/java/com/glancy/backend/controller/UserControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/UserControllerTest.java
@@ -19,6 +19,8 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 @WebMvcTest(UserController.class)
 @Import(com.glancy.backend.config.SecurityConfig.class)
@@ -147,6 +149,17 @@ class UserControllerTest {
                         .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.avatar").value("url"));
+    }
+
+    @Test
+    void uploadAvatar() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("file", "a.jpg", "image/jpeg", "xx".getBytes());
+        AvatarResponse resp = new AvatarResponse("path/url.jpg");
+        when(userService.uploadAvatar(eq(1L), any(MultipartFile.class))).thenReturn(resp);
+
+        mockMvc.perform(multipart("/api/users/1/avatar-file").file(file))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.avatar").value("path/url.jpg"));
     }
 
     @Test

--- a/src/test/java/com/glancy/backend/service/UserServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/UserServiceTest.java
@@ -8,6 +8,8 @@ import com.glancy.backend.entity.User;
 import com.glancy.backend.entity.LoginDevice;
 import com.glancy.backend.repository.UserRepository;
 import com.glancy.backend.repository.LoginDeviceRepository;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.multipart.MultipartFile;
 
 import io.github.cdimascio.dotenv.Dotenv;
 
@@ -19,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.BeforeAll;
 
@@ -32,6 +35,8 @@ class UserServiceTest {
     private UserRepository userRepository;
     @Autowired
     private LoginDeviceRepository loginDeviceRepository;
+    @MockitoBean
+    private AvatarStorageService avatarStorageService;
 
     @BeforeAll
     static void loadEnv() {
@@ -202,6 +207,22 @@ class UserServiceTest {
 
         AvatarResponse fetched = userService.getAvatar(resp.getId());
         assertEquals("url", fetched.getAvatar());
+    }
+
+    @Test
+    void testUploadAvatar() throws Exception {
+        UserRegistrationRequest req = new UserRegistrationRequest();
+        req.setUsername("uploaduser");
+        req.setPassword("pass");
+        req.setEmail("up@example.com");
+        req.setPhone("109");
+        UserResponse resp = userService.register(req);
+
+        MultipartFile file = mock(MultipartFile.class);
+        when(avatarStorageService.upload(file)).thenReturn("path/url.jpg");
+
+        AvatarResponse result = userService.uploadAvatar(resp.getId(), file);
+        assertEquals("path/url.jpg", result.getAvatar());
     }
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,3 +18,9 @@ logging:
 
 portal:
   admin-token: secret
+oss:
+  endpoint: https://oss-cn-hangzhou.aliyuncs.com
+  bucket: glancy-avatar-bucket
+  avatar-dir: avatars/
+  access-key-id:
+  access-key-secret:


### PR DESCRIPTION
## Summary
- integrate AvatarStorageService using Aliyun OSS SDK
- load OSS credentials from environment
- provide `/api/users/{id}/avatar-file` endpoint
- update tests and configs for new avatar upload logic

## Testing
- `./mvnw test -q`

------
https://chatgpt.com/codex/tasks/task_e_687a954f2d44833298399b1e0c41f822