### PR TITLE
[Feature] simplify login request

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ English prompt guidance can be found in `PROMPT_GUIDE_EN.md`.
 - `POST /api/users/register` – register a new user
 - `DELETE /api/users/{id}` – logically delete a user
 - `GET /api/users/{id}` – fetch user details
-- `POST /api/users/login` – user login (send `identifier` with `type` and `text` along with `password`)
+- `POST /api/users/login` – user login (send `account` and `password`)
 - 登录成功后将返回 `token`，后续需要在 `X-USER-TOKEN` 请求头中携带此值
 - `POST /api/users/{id}/third-party-accounts` – bind a third‑party account (returns the bound account)
 - `GET /api/users/count` – total number of active users

--- a/scripts/curl-tests.sh
+++ b/scripts/curl-tests.sh
@@ -21,7 +21,7 @@ curl -i -H "Content-Type: application/json" \
 
 section "Login"
 curl -i -H "Content-Type: application/json" \
-    -d '{"identifier":{"type":"USERNAME","text":"demo"},"password":"pass123"}' \
+    -d '{"account":"demo","password":"pass123"}' \
     "$BASE_URL/api/users/login"
 
 section "Create FAQ"

--- a/src/main/java/com/glancy/backend/dto/LoginRequest.java
+++ b/src/main/java/com/glancy/backend/dto/LoginRequest.java
@@ -9,9 +9,9 @@ import lombok.Data;
 @Data
 public class LoginRequest {
     /**
-     * Identifier containing the raw text and resolved type.
+     * Account string entered by the user. May be a username, email or phone number.
      */
-    private LoginIdentifier identifier;
+    private String account;
 
     @NotBlank(message = "{validation.login.password.notblank}")
     private String password;

--- a/src/main/java/com/glancy/backend/service/UserService.java
+++ b/src/main/java/com/glancy/backend/service/UserService.java
@@ -112,22 +112,19 @@ public class UserService {
      */
     @Transactional
     public LoginResponse login(LoginRequest req) {
-        LoginIdentifier id = req.getIdentifier();
-        if (id == null || id.getText() == null || id.getText().isEmpty()) {
-            log.warn("No identifier provided for login");
+        String account = req.getAccount();
+        if (account == null || account.isEmpty()) {
+            log.warn("No account provided for login");
             throw new IllegalArgumentException("用户名、邮箱或手机号必须填写其一");
         }
 
-        LoginIdentifier.Type type = id.getType();
-        if (type == null) {
-            type = LoginIdentifier.resolveType(id.getText());
-        }
+        LoginIdentifier.Type type = LoginIdentifier.resolveType(account);
 
         String identifier;
         User user;
         switch (type) {
             case EMAIL:
-                identifier = id.getText();
+                identifier = account;
                 final String email = identifier;
                 user = userRepository.findByEmailAndDeletedFalse(email)
                         .orElseThrow(() -> {
@@ -136,7 +133,7 @@ public class UserService {
                         });
                 break;
             case PHONE:
-                identifier = id.getText();
+                identifier = account;
                 String phone = identifier;
                 if (!phone.startsWith("+")) {
                     phone = "+86" + phone;
@@ -153,7 +150,7 @@ public class UserService {
                 break;
             case USERNAME:
             default:
-                identifier = id.getText();
+                identifier = account;
                 final String uname = identifier;
                 user = userRepository.findByUsernameAndDeletedFalse(uname)
                         .orElseThrow(() -> {

--- a/src/test/java/com/glancy/backend/controller/UserControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/UserControllerTest.java
@@ -83,11 +83,8 @@ class UserControllerTest {
         LoginResponse resp = new LoginResponse(1L, "u", "e", null, null, false, "tkn");
         when(userService.login(any(LoginRequest.class))).thenReturn(resp);
 
-        LoginIdentifier id = new LoginIdentifier();
-        id.setType(LoginIdentifier.Type.USERNAME);
-        id.setText("u");
         LoginRequest req = new LoginRequest();
-        req.setIdentifier(id);
+        req.setAccount("u");
         req.setPassword("pass");
 
         mockMvc.perform(post("/api/users/login")
@@ -102,11 +99,8 @@ class UserControllerTest {
         LoginResponse resp = new LoginResponse(1L, "u", "e", null, "555", false, "tkn");
         when(userService.login(any(LoginRequest.class))).thenReturn(resp);
 
-        LoginIdentifier id = new LoginIdentifier();
-        id.setType(LoginIdentifier.Type.PHONE);
-        id.setText("555");
         LoginRequest req = new LoginRequest();
-        req.setIdentifier(id);
+        req.setAccount("555");
         req.setPassword("pass");
 
         mockMvc.perform(post("/api/users/login")

--- a/src/test/java/com/glancy/backend/service/UserServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/UserServiceTest.java
@@ -3,7 +3,6 @@ package com.glancy.backend.service;
 import com.glancy.backend.dto.UserRegistrationRequest;
 import com.glancy.backend.dto.UserResponse;
 import com.glancy.backend.dto.LoginRequest;
-import com.glancy.backend.dto.LoginIdentifier;
 import com.glancy.backend.dto.AvatarResponse;
 import com.glancy.backend.entity.User;
 import com.glancy.backend.entity.LoginDevice;
@@ -159,11 +158,8 @@ class UserServiceTest {
         req.setPhone("103");
         UserResponse resp = userService.register(req);
 
-        LoginIdentifier id = new LoginIdentifier();
-        id.setType(LoginIdentifier.Type.USERNAME);
-        id.setText("deviceuser");
         LoginRequest loginReq = new LoginRequest();
-        loginReq.setIdentifier(id);
+        loginReq.setAccount("deviceuser");
         loginReq.setPassword("pass123");
 
         loginReq.setDeviceInfo("d1");
@@ -190,11 +186,8 @@ class UserServiceTest {
         req.setPhone("555");
         userService.register(req);
 
-        LoginIdentifier id = new LoginIdentifier();
-        id.setType(LoginIdentifier.Type.PHONE);
-        id.setText("555");
         LoginRequest loginReq = new LoginRequest();
-        loginReq.setIdentifier(id);
+        loginReq.setAccount("555");
         loginReq.setPassword("pass123");
 
         assertNotNull(userService.login(loginReq).getToken());


### PR DESCRIPTION
## Summary
- accept `account` instead of `identifier` when logging in
- adjust service logic to resolve account type
- update tests and curl script for the new payload
- document the new login parameter

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_687aaa46809c83328f58e8b4ead8cbb7