### PR TITLE
[Fix] Allow credentials in CORS config

### DIFF
--- a/src/main/java/com/glancy/backend/config/WebConfig.java
+++ b/src/main/java/com/glancy/backend/config/WebConfig.java
@@ -11,7 +11,9 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(@NonNull CorsRegistry registry) {
         registry.addMapping("/api/**")
-            .allowedOrigins("*")
-            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
+            .allowedOriginPatterns("*")
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true);
     }
 }


### PR DESCRIPTION
## Summary
- enable credentials for CORS requests by updating WebConfig

## Testing
- `./mvnw test -q`


------
https://chatgpt.com/codex/tasks/task_e_687d2073808c8332a121dc49760539e2