### PR TITLE
[Feature] Add restart workflow

### DIFF
--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -1,0 +1,18 @@
+name: Restart Backend
+
+on:
+    workflow_dispatch:
+
+jobs:
+    restart:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Restart backend service
+              uses: appleboy/ssh-action@v1.0.0
+              with:
+                  host: ${{ secrets.SERVER_HOST }}
+                  username: ${{ secrets.SERVER_USER }}
+                  key: ${{ secrets.SERVER_KEY }}
+                  script: |
+                      sudo systemctl restart glancy-backend.service
+


### PR DESCRIPTION
## Summary
- add `.github/workflows/restart.yml` for one-click backend restart via SSH

## Testing
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_687d30bbee84833280cc7f9752a75533