### PR TITLE
[Refactor] Update DeepSeek client to use POST

### DIFF
--- a/src/test/java/com/glancy/backend/client/DeepSeekClientTest.java
+++ b/src/test/java/com/glancy/backend/client/DeepSeekClientTest.java
@@ -13,6 +13,7 @@ import org.springframework.web.client.RestTemplate;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
@@ -30,9 +31,11 @@ class DeepSeekClientTest {
     @Test
     void fetchDefinitionWithAuth() {
         String json = "{\"id\":null,\"term\":\"hello\",\"definitions\":[\"hi\"],\"language\":\"ENGLISH\",\"example\":null,\"phonetic\":null}";
-        server.expect(requestTo("http://mock/words/definition?term=hello&language=english"))
-                .andExpect(method(GET))
+        server.expect(requestTo("http://mock/v1/chat/completions"))
+                .andExpect(method(POST))
                 .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer key"))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.messages[1].content").value("hello"))
                 .andRespond(withSuccess(json, MediaType.APPLICATION_JSON));
 
         WordResponse resp = client.fetchDefinition("hello", Language.ENGLISH);


### PR DESCRIPTION
## Summary
- modify `DeepSeekClient.fetchDefinition` to call DeepSeek chat API with JSON
- adjust `DeepSeekClientTest` to match the new POST request

## Testing
- `./mvnw test -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4da451bc83328a75d64874c83472