### PR TITLE
[Feature] Provide defaults for user preferences

### DIFF
--- a/src/main/java/com/glancy/backend/service/UserPreferenceService.java
+++ b/src/main/java/com/glancy/backend/service/UserPreferenceService.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.extern.slf4j.Slf4j;
 
+import com.glancy.backend.entity.DictionaryModel;
+
 import com.glancy.backend.dto.UserPreferenceRequest;
 import com.glancy.backend.dto.UserPreferenceResponse;
 import com.glancy.backend.entity.User;
@@ -21,10 +23,27 @@ public class UserPreferenceService {
     private final UserPreferenceRepository userPreferenceRepository;
     private final UserRepository userRepository;
 
+    private static final String DEFAULT_THEME = "light";
+    private static final String DEFAULT_SYSTEM_LANGUAGE = "en";
+    private static final String DEFAULT_SEARCH_LANGUAGE = "en";
+    private static final DictionaryModel DEFAULT_DICTIONARY_MODEL = DictionaryModel.DEEPSEEK;
+
     public UserPreferenceService(UserPreferenceRepository userPreferenceRepository,
                                  UserRepository userRepository) {
         this.userPreferenceRepository = userPreferenceRepository;
         this.userRepository = userRepository;
+    }
+
+    private UserPreference createDefaultPreference(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("用户不存在"));
+        UserPreference pref = new UserPreference();
+        pref.setUser(user);
+        pref.setTheme(DEFAULT_THEME);
+        pref.setSystemLanguage(DEFAULT_SYSTEM_LANGUAGE);
+        pref.setSearchLanguage(DEFAULT_SEARCH_LANGUAGE);
+        pref.setDictionaryModel(DEFAULT_DICTIONARY_MODEL);
+        return pref;
     }
 
     /**
@@ -53,7 +72,7 @@ public class UserPreferenceService {
     public UserPreferenceResponse getPreference(Long userId) {
         log.info("Fetching preferences for user {}", userId);
         UserPreference pref = userPreferenceRepository.findByUserId(userId)
-                .orElseThrow(() -> new IllegalArgumentException("未找到用户设置"));
+                .orElseGet(() -> createDefaultPreference(userId));
         return toResponse(pref);
     }
 

--- a/src/main/java/com/glancy/backend/service/WordService.java
+++ b/src/main/java/com/glancy/backend/service/WordService.java
@@ -6,6 +6,7 @@ import com.glancy.backend.client.DeepSeekClient;
 import com.glancy.backend.client.QianWenClient;
 import com.glancy.backend.entity.DictionaryModel;
 import com.glancy.backend.repository.UserPreferenceRepository;
+import com.glancy.backend.entity.UserPreference;
 import com.glancy.backend.service.dictionary.DeepSeekStrategy;
 import com.glancy.backend.service.dictionary.DictionaryStrategy;
 import com.glancy.backend.service.dictionary.QianWenStrategy;
@@ -79,7 +80,11 @@ public class WordService {
     @Transactional
     public WordResponse findWordForUser(Long userId, String term, Language language) {
         var pref = userPreferenceRepository.findByUserId(userId)
-                .orElseThrow(() -> new IllegalArgumentException("未找到用户设置"));
+                .orElseGet(() -> {
+                    UserPreference p = new UserPreference();
+                    p.setDictionaryModel(DictionaryModel.DEEPSEEK);
+                    return p;
+                });
         DictionaryModel model = pref.getDictionaryModel();
         DictionaryStrategy strategy = strategies.get(model);
         if (model == DictionaryModel.DEEPSEEK) {

--- a/src/test/java/com/glancy/backend/service/UserPreferenceServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/UserPreferenceServiceTest.java
@@ -68,4 +68,19 @@ class UserPreferenceServiceTest {
         assertEquals("zh", fetched.getSearchLanguage());
         assertEquals(DictionaryModel.DEEPSEEK, fetched.getDictionaryModel());
     }
+
+    @Test
+    void testDefaultPreferenceWhenMissing() {
+        User user = new User();
+        user.setUsername("prefuser2");
+        user.setPassword("pass");
+        user.setEmail("pref2@example.com");
+        user.setPhone("33");
+        userRepository.save(user);
+
+        UserPreferenceResponse fetched = userPreferenceService.getPreference(user.getId());
+        assertEquals("light", fetched.getTheme());
+        assertEquals("en", fetched.getSystemLanguage());
+        assertEquals(DictionaryModel.DEEPSEEK, fetched.getDictionaryModel());
+    }
 }


### PR DESCRIPTION
## Summary
- add default values for theme, languages and dictionary model
- return these defaults when no user preference exists
- use default dictionary model in word lookups when preference missing
- test default preference behaviour

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_687d51f906808332a7a08160f4ebdd74