### PR TITLE
[Fix] Handle string ID from dictionary APIs

### DIFF
--- a/src/main/java/com/glancy/backend/dto/WordResponse.java
+++ b/src/main/java/com/glancy/backend/dto/WordResponse.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Data
 @AllArgsConstructor
 public class WordResponse {
-    private Long id;
+    private String id;
     private String term;
     private List<String> definitions;
     private Language language;

--- a/src/main/java/com/glancy/backend/service/WordService.java
+++ b/src/main/java/com/glancy/backend/service/WordService.java
@@ -107,11 +107,11 @@ public class WordService {
         word.setExample(resp.getExample());
         word.setPhonetic(resp.getPhonetic());
         Word saved = wordRepository.save(word);
-        resp.setId(saved.getId());
+        resp.setId(String.valueOf(saved.getId()));
     }
 
     private WordResponse toResponse(Word word) {
-        return new WordResponse(word.getId(), word.getTerm(), word.getDefinitions(),
+        return new WordResponse(String.valueOf(word.getId()), word.getTerm(), word.getDefinitions(),
                 word.getLanguage(), word.getExample(), word.getPhonetic());
     }
 }

--- a/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -39,7 +39,7 @@ class WordControllerTest {
 
     @Test
     void testGetWord() throws Exception {
-        WordResponse resp = new WordResponse(1L, "hello", List.of("g"), Language.ENGLISH, "ex", "həˈloʊ");
+        WordResponse resp = new WordResponse("1", "hello", List.of("g"), Language.ENGLISH, "ex", "həˈloʊ");
         when(wordService.findWordForUser(eq(1L), eq("hello"), eq(Language.ENGLISH))).thenReturn(resp);
 
         doNothing().when(userService).validateToken(1L, "tkn");
@@ -52,7 +52,7 @@ class WordControllerTest {
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.id").value("1"))
                 .andExpect(jsonPath("$.term").value("hello"));
     }
 

--- a/src/test/java/com/glancy/backend/service/WordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/WordServiceTest.java
@@ -70,7 +70,7 @@ class WordServiceTest {
         assertNotNull(result.getId());
         assertEquals("greeting", result.getDefinitions().get(0));
         verify(deepSeekClient, times(1)).fetchDefinition("hello", Language.ENGLISH);
-        assertTrue(wordRepository.findById(result.getId()).isPresent());
+        assertTrue(wordRepository.findById(Long.parseLong(result.getId())).isPresent());
     }
 
     @Test
@@ -83,13 +83,13 @@ class WordServiceTest {
 
         WordResponse result = wordService.findWordFromDeepSeek("cached", Language.ENGLISH);
 
-        assertEquals(word.getId(), result.getId());
+        assertEquals(String.valueOf(word.getId()), result.getId());
         verify(deepSeekClient, never()).fetchDefinition(anyString(), any());
     }
 
     @Test
     void testFindWordFromQianWen() {
-        WordResponse resp = new WordResponse(1L, "hello",
+        WordResponse resp = new WordResponse("1", "hello",
                 List.of("salutation"), Language.ENGLISH, "Hello world", "həˈloʊ");
         when(qianWenClient.fetchDefinition("hello", Language.ENGLISH))
                 .thenReturn(resp);


### PR DESCRIPTION
## Summary
- change `WordResponse` id type to `String` so external APIs returning UUID won't fail
- adjust `WordService` to convert DB IDs to string
- update controller and service tests accordingly

## Testing
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_687d57b9b5348332b6487cc2a85455ac