### PR TITLE
[Fix] handle missing language in word caching

### DIFF
--- a/src/main/java/com/glancy/backend/service/WordService.java
+++ b/src/main/java/com/glancy/backend/service/WordService.java
@@ -54,7 +54,7 @@ public class WordService {
                 .map(this::toResponse)
                 .orElseGet(() -> {
                     WordResponse resp = deepSeekClient.fetchDefinition(term, language);
-                    saveWord(resp);
+                    saveWord(resp, language);
                     return resp;
                 });
     }
@@ -92,22 +92,24 @@ public class WordService {
                     .map(this::toResponse)
                     .orElseGet(() -> {
                         WordResponse resp = strategy.fetch(term, language);
-                        saveWord(resp);
+                        saveWord(resp, language);
                         return resp;
                     });
         }
         return strategy.fetch(term, language);
     }
 
-    private void saveWord(WordResponse resp) {
+    private void saveWord(WordResponse resp, Language language) {
         Word word = new Word();
         word.setTerm(resp.getTerm());
-        word.setLanguage(resp.getLanguage());
+        Language lang = resp.getLanguage() != null ? resp.getLanguage() : language;
+        word.setLanguage(lang);
         word.setDefinitions(resp.getDefinitions());
         word.setExample(resp.getExample());
         word.setPhonetic(resp.getPhonetic());
         Word saved = wordRepository.save(word);
         resp.setId(String.valueOf(saved.getId()));
+        resp.setLanguage(lang);
     }
 
     private WordResponse toResponse(Word word) {

--- a/src/test/java/com/glancy/backend/service/WordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/WordServiceTest.java
@@ -122,6 +122,17 @@ class WordServiceTest {
     }
 
     @Test
+    void testCacheWordWhenLanguageMissing() {
+        WordResponse resp = new WordResponse(null, "bye", List.of("farewell"), null, null, null);
+        when(deepSeekClient.fetchDefinition("bye", Language.ENGLISH)).thenReturn(resp);
+
+        WordResponse result = wordService.findWordFromDeepSeek("bye", Language.ENGLISH);
+
+        assertEquals(Language.ENGLISH, result.getLanguage());
+        assertTrue(wordRepository.findByTermAndLanguageAndDeletedFalse("bye", Language.ENGLISH).isPresent());
+    }
+
+    @Test
     void testSaveSameTermDifferentLanguage() {
         Word wordEn = new Word();
         wordEn.setTerm("hello");


### PR DESCRIPTION
## Summary
- ensure saved words have a language even if API response omits it
- cover null-language scenario in WordService tests

## Testing
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_687d5bb271448332b5e1f4c70aceb208