### PR TITLE
[Feature] Add logout API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ English prompt guidance can be found in `PROMPT_GUIDE_EN.md`.
 - `GET /api/users/{id}` – fetch user details
 - `POST /api/users/login` – user login (send `account` and `password`)
 - 登录成功后将返回 `token`，后续需要在 `X-USER-TOKEN` 请求头中携带此值
+- `POST /api/users/{id}/logout` – invalidate the login token
 - `POST /api/users/{id}/third-party-accounts` – bind a third‑party account (returns the bound account)
 - `GET /api/users/count` – total number of active users
 

--- a/scripts/curl-tests.sh
+++ b/scripts/curl-tests.sh
@@ -24,6 +24,10 @@ curl -i -H "Content-Type: application/json" \
     -d '{"account":"demo","password":"pass123"}' \
     "$BASE_URL/api/users/login"
 
+section "Logout"
+curl -i -H "X-USER-TOKEN: TOKEN" \
+    -X POST "$BASE_URL/api/users/1/logout"
+
 section "Create FAQ"
 curl -i -H "Content-Type: application/json" \
     -d '{"question":"What?","answer":"It works"}' \

--- a/src/main/java/com/glancy/backend/controller/UserController.java
+++ b/src/main/java/com/glancy/backend/controller/UserController.java
@@ -70,6 +70,16 @@ public class UserController {
     }
 
     /**
+     * Log out a user by clearing their login token.
+     */
+    @PostMapping("/{id}/logout")
+    public ResponseEntity<Void> logout(@PathVariable Long id,
+                                       @RequestHeader("X-USER-TOKEN") String token) {
+        userService.logout(id, token);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
      * Bind a third-party account to the specified user.
      */
     @PostMapping("/{id}/third-party-accounts")

--- a/src/main/java/com/glancy/backend/service/UserService.java
+++ b/src/main/java/com/glancy/backend/service/UserService.java
@@ -264,6 +264,20 @@ public class UserService {
     }
 
     /**
+     * Invalidate the login token for a user, effectively logging them out.
+     */
+    @Transactional
+    public void logout(Long userId, String token) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("用户不存在"));
+        if (token == null || !token.equals(user.getLoginToken())) {
+            throw new IllegalArgumentException("无效的用户令牌");
+        }
+        user.setLoginToken(null);
+        userRepository.save(user);
+    }
+
+    /**
      * Retrieve only the avatar URL of a user.
      */
     @Transactional(readOnly = true)

--- a/src/test/java/com/glancy/backend/controller/UserControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/UserControllerTest.java
@@ -163,6 +163,15 @@ class UserControllerTest {
     }
 
     @Test
+    void logout() throws Exception {
+        doNothing().when(userService).logout(1L, "tkn");
+
+        mockMvc.perform(post("/api/users/1/logout")
+                        .header("X-USER-TOKEN", "tkn"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
     void countUsers() throws Exception {
         when(userService.countActiveUsers()).thenReturn(5L);
         mockMvc.perform(get("/api/users/count"))

--- a/src/test/java/com/glancy/backend/service/UserServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/UserServiceTest.java
@@ -194,6 +194,26 @@ class UserServiceTest {
     }
 
     @Test
+    void testLogout() {
+        UserRegistrationRequest req = new UserRegistrationRequest();
+        req.setUsername("logoutuser");
+        req.setPassword("pass123");
+        req.setEmail("logout@example.com");
+        req.setPhone("888");
+        UserResponse resp = userService.register(req);
+
+        LoginRequest loginReq = new LoginRequest();
+        loginReq.setAccount("logoutuser");
+        loginReq.setPassword("pass123");
+        String token = userService.login(loginReq).getToken();
+
+        userService.logout(resp.getId(), token);
+
+        User user = userRepository.findById(resp.getId()).orElseThrow();
+        assertNull(user.getLoginToken());
+    }
+
+    @Test
     void testUpdateAvatar() {
         UserRegistrationRequest req = new UserRegistrationRequest();
         req.setUsername("avataruser");


### PR DESCRIPTION
## Summary
- implement `/api/users/{id}/logout` endpoint for clearing login tokens
- add `logout` method to `UserService`
- document the endpoint and update curl test script
- add unit tests for controller and service

## Testing
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_687d80a7db1c833288c572ff76b1761c