### PR TITLE
[Fix] avoid duplicate search history

### DIFF
--- a/src/main/java/com/glancy/backend/repository/SearchRecordRepository.java
+++ b/src/main/java/com/glancy/backend/repository/SearchRecordRepository.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.time.LocalDateTime;
+import com.glancy.backend.entity.Language;
 
 /**
  * Repository for persisting and querying user search history.
@@ -15,4 +16,6 @@ public interface SearchRecordRepository extends JpaRepository<SearchRecord, Long
     List<SearchRecord> findByUserIdOrderByCreatedAtDesc(Long userId);
     void deleteByUserId(Long userId);
     long countByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
+    boolean existsByUserIdAndTermAndLanguage(Long userId, String term, Language language);
+    SearchRecord findTopByUserIdAndTermAndLanguageOrderByCreatedAtDesc(Long userId, String term, Language language);
 }

--- a/src/main/java/com/glancy/backend/service/SearchRecordService.java
+++ b/src/main/java/com/glancy/backend/service/SearchRecordService.java
@@ -51,6 +51,13 @@ public class SearchRecordService {
             log.warn("User {} is not logged in", userId);
             throw new IllegalStateException("用户未登录");
         }
+        SearchRecord existing = searchRecordRepository
+                .findTopByUserIdAndTermAndLanguageOrderByCreatedAtDesc(userId,
+                        request.getTerm(), request.getLanguage());
+        if (existing != null) {
+            return toResponse(existing);
+        }
+
         if (Boolean.FALSE.equals(user.getMember())) {
             LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
             LocalDateTime endOfDay = startOfDay.plusDays(1);


### PR DESCRIPTION
## Summary
- prevent saving duplicate search terms for a user
- adjust search history limit test
- add test for duplicate search record logic

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_687e2ced157083328c192b9e78b65896