### PR TITLE
[Feature] Delete single search record

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ English prompt guidance can be found in `PROMPT_GUIDE_EN.md`.
 
 - `POST /api/search-records/user/{userId}` – add a new search record for the user
 - `GET /api/search-records/user/{userId}` – list search records of the user
+- `DELETE /api/search-records/user/{userId}/{recordId}` – delete a specific search record of the user
 - `DELETE /api/search-records/user/{userId}` – clear all search records of the user
   以上接口均需在 `X-USER-TOKEN` 请求头中提供登录令牌
 

--- a/scripts/curl-tests.sh
+++ b/scripts/curl-tests.sh
@@ -78,6 +78,9 @@ curl -i -H "Content-Type: application/json" \
 section "List search records"
 curl -i "$BASE_URL/api/search-records/user/1"
 
+section "Delete one search record"
+curl -i -X DELETE "$BASE_URL/api/search-records/user/1/1"
+
 section "Lookup word"
 curl -i "$BASE_URL/api/words?userId=1&term=hello&language=ENGLISH"
 

--- a/src/main/java/com/glancy/backend/controller/SearchRecordController.java
+++ b/src/main/java/com/glancy/backend/controller/SearchRecordController.java
@@ -61,4 +61,16 @@ public class SearchRecordController {
         searchRecordService.clearRecords(userId);
         return ResponseEntity.noContent().build();
     }
+
+    /**
+     * Delete a specific search record of a user.
+     */
+    @DeleteMapping("/user/{userId}/{recordId}")
+    public ResponseEntity<Void> delete(@PathVariable Long userId,
+                                       @PathVariable Long recordId,
+                                       @RequestHeader("X-USER-TOKEN") String token) {
+        userService.validateToken(userId, token);
+        searchRecordService.deleteRecord(userId, recordId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/glancy/backend/service/SearchRecordService.java
+++ b/src/main/java/com/glancy/backend/service/SearchRecordService.java
@@ -95,6 +95,20 @@ public class SearchRecordService {
         searchRecordRepository.deleteByUserId(userId);
     }
 
+    /**
+     * Delete a single search record belonging to the given user.
+     */
+    @Transactional
+    public void deleteRecord(Long userId, Long recordId) {
+        log.info("Deleting search record {} for user {}", recordId, userId);
+        SearchRecord record = searchRecordRepository.findById(recordId)
+                .orElseThrow(() -> new IllegalArgumentException("搜索记录不存在"));
+        if (!record.getUser().getId().equals(userId)) {
+            throw new IllegalArgumentException("搜索记录不存在");
+        }
+        searchRecordRepository.delete(record);
+    }
+
     private SearchRecordResponse toResponse(SearchRecord record) {
         return new SearchRecordResponse(record.getId(), record.getUser().getId(),
                 record.getTerm(), record.getLanguage(), record.getCreatedAt());

--- a/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
@@ -65,4 +65,14 @@ class SearchRecordControllerTest {
                 .andExpect(jsonPath("$[0].id").value(1))
                 .andExpect(jsonPath("$[0].term").value("hello"));
     }
+
+    @Test
+    void testDelete() throws Exception {
+        doNothing().when(searchRecordService).deleteRecord(1L, 2L);
+        doNothing().when(userService).validateToken(1L, "tkn");
+
+        mockMvc.perform(delete("/api/search-records/user/1/2")
+                .header("X-USER-TOKEN", "tkn"))
+                .andExpect(status().isNoContent());
+    }
 }

--- a/src/test/java/com/glancy/backend/service/SearchRecordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/SearchRecordServiceTest.java
@@ -138,4 +138,54 @@ class SearchRecordServiceTest {
         List<SearchRecordResponse> list = searchRecordService.getRecords(user.getId());
         assertEquals(1, list.size());
     }
+
+    @Test
+    void testDeleteRecord() {
+        User user = new User();
+        user.setUsername("del");
+        user.setPassword("p");
+        user.setEmail("del@example.com");
+        user.setPhone("45");
+        userRepository.save(user);
+        user.setLastLoginAt(LocalDateTime.now());
+        userRepository.save(user);
+
+        SearchRecordRequest req = new SearchRecordRequest();
+        req.setTerm("bye");
+        req.setLanguage(Language.ENGLISH);
+        SearchRecordResponse saved = searchRecordService.saveRecord(user.getId(), req);
+
+        searchRecordService.deleteRecord(user.getId(), saved.getId());
+        assertTrue(searchRecordService.getRecords(user.getId()).isEmpty());
+    }
+
+    @Test
+    void testDeleteRecordWrongUser() {
+        User u1 = new User();
+        u1.setUsername("owner");
+        u1.setPassword("p");
+        u1.setEmail("o@example.com");
+        u1.setPhone("46");
+        userRepository.save(u1);
+        u1.setLastLoginAt(LocalDateTime.now());
+        userRepository.save(u1);
+
+        User u2 = new User();
+        u2.setUsername("other");
+        u2.setPassword("p");
+        u2.setEmail("other@example.com");
+        u2.setPhone("47");
+        userRepository.save(u2);
+        u2.setLastLoginAt(LocalDateTime.now());
+        userRepository.save(u2);
+
+        SearchRecordRequest req = new SearchRecordRequest();
+        req.setTerm("yo");
+        req.setLanguage(Language.ENGLISH);
+        SearchRecordResponse saved = searchRecordService.saveRecord(u1.getId(), req);
+
+        Exception ex = assertThrows(IllegalArgumentException.class,
+                () -> searchRecordService.deleteRecord(u2.getId(), saved.getId()));
+        assertEquals("搜索记录不存在", ex.getMessage());
+    }
 }


### PR DESCRIPTION
## Summary
- support removing a single search history entry
- document new endpoint and update curl script
- add unit tests for deleting records

## Testing
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_687e366e647c833292c9de8d00403b11