### PR TITLE
[Feature] allow unfavoriting search records

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ English prompt guidance can be found in `PROMPT_GUIDE_EN.md`.
 - `POST /api/search-records/user/{userId}` – add a new search record for the user
 - `GET /api/search-records/user/{userId}` – list search records of the user
 - `DELETE /api/search-records/user/{userId}` – clear all search records of the user
+- `DELETE /api/search-records/user/{userId}/{recordId}/favorite` – unfavorite a search record
   以上接口均需在 `X-USER-TOKEN` 请求头中提供登录令牌
 
 

--- a/scripts/curl-tests.sh
+++ b/scripts/curl-tests.sh
@@ -78,6 +78,9 @@ curl -i -H "Content-Type: application/json" \
 section "List search records"
 curl -i "$BASE_URL/api/search-records/user/1"
 
+section "Unfavorite search record"
+curl -i -X DELETE "$BASE_URL/api/search-records/user/1/1/favorite"
+
 section "Lookup word"
 curl -i "$BASE_URL/api/words?userId=1&term=hello&language=ENGLISH"
 

--- a/src/main/java/com/glancy/backend/controller/SearchRecordController.java
+++ b/src/main/java/com/glancy/backend/controller/SearchRecordController.java
@@ -61,4 +61,16 @@ public class SearchRecordController {
         searchRecordService.clearRecords(userId);
         return ResponseEntity.noContent().build();
     }
+
+    /**
+     * Cancel favorite for a specific search record of the user.
+     */
+    @DeleteMapping("/user/{userId}/{recordId}/favorite")
+    public ResponseEntity<Void> unfavorite(@PathVariable Long userId,
+                                           @PathVariable Long recordId,
+                                           @RequestHeader("X-USER-TOKEN") String token) {
+        userService.validateToken(userId, token);
+        searchRecordService.unfavoriteRecord(userId, recordId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/glancy/backend/dto/SearchRecordResponse.java
+++ b/src/main/java/com/glancy/backend/dto/SearchRecordResponse.java
@@ -17,4 +17,5 @@ public class SearchRecordResponse {
     private String term;
     private Language language;
     private LocalDateTime createdAt;
+    private Boolean favorite;
 }

--- a/src/main/java/com/glancy/backend/entity/SearchRecord.java
+++ b/src/main/java/com/glancy/backend/entity/SearchRecord.java
@@ -30,5 +30,8 @@ public class SearchRecord {
     private Language language;
 
     @Column(nullable = false)
+    private Boolean favorite = false;
+
+    @Column(nullable = false)
     private LocalDateTime createdAt = LocalDateTime.now();
 }

--- a/src/main/java/com/glancy/backend/repository/SearchRecordRepository.java
+++ b/src/main/java/com/glancy/backend/repository/SearchRecordRepository.java
@@ -18,4 +18,5 @@ public interface SearchRecordRepository extends JpaRepository<SearchRecord, Long
     long countByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
     boolean existsByUserIdAndTermAndLanguage(Long userId, String term, Language language);
     SearchRecord findTopByUserIdAndTermAndLanguageOrderByCreatedAtDesc(Long userId, String term, Language language);
+    java.util.Optional<SearchRecord> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/glancy/backend/service/SearchRecordService.java
+++ b/src/main/java/com/glancy/backend/service/SearchRecordService.java
@@ -95,8 +95,20 @@ public class SearchRecordService {
         searchRecordRepository.deleteByUserId(userId);
     }
 
+    /**
+     * Cancel favorite status for a user's search record.
+     */
+    @Transactional
+    public void unfavoriteRecord(Long userId, Long recordId) {
+        log.info("Unfavoriting search record {} for user {}", recordId, userId);
+        SearchRecord record = searchRecordRepository.findByIdAndUserId(recordId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("记录不存在"));
+        record.setFavorite(false);
+        searchRecordRepository.save(record);
+    }
+
     private SearchRecordResponse toResponse(SearchRecord record) {
         return new SearchRecordResponse(record.getId(), record.getUser().getId(),
-                record.getTerm(), record.getLanguage(), record.getCreatedAt());
+                record.getTerm(), record.getLanguage(), record.getCreatedAt(), record.getFavorite());
     }
 }

--- a/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
@@ -38,7 +38,7 @@ class SearchRecordControllerTest {
 
     @Test
     void testCreate() throws Exception {
-        SearchRecordResponse resp = new SearchRecordResponse(1L, 1L, "hello", Language.ENGLISH, LocalDateTime.now());
+        SearchRecordResponse resp = new SearchRecordResponse(1L, 1L, "hello", Language.ENGLISH, LocalDateTime.now(), false);
         when(searchRecordService.saveRecord(any(Long.class), any(SearchRecordRequest.class))).thenReturn(resp);
 
         doNothing().when(userService).validateToken(1L, "tkn");
@@ -54,7 +54,7 @@ class SearchRecordControllerTest {
 
     @Test
     void testList() throws Exception {
-        SearchRecordResponse resp = new SearchRecordResponse(1L, 1L, "hello", Language.ENGLISH, LocalDateTime.now());
+        SearchRecordResponse resp = new SearchRecordResponse(1L, 1L, "hello", Language.ENGLISH, LocalDateTime.now(), false);
         when(searchRecordService.getRecords(1L)).thenReturn(Collections.singletonList(resp));
 
         doNothing().when(userService).validateToken(1L, "tkn");
@@ -64,5 +64,15 @@ class SearchRecordControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(1))
                 .andExpect(jsonPath("$[0].term").value("hello"));
+    }
+
+    @Test
+    void testUnfavorite() throws Exception {
+        doNothing().when(userService).validateToken(1L, "tkn");
+        doNothing().when(searchRecordService).unfavoriteRecord(1L, 2L);
+
+        mockMvc.perform(delete("/api/search-records/user/1/2/favorite")
+                .header("X-USER-TOKEN", "tkn"))
+                .andExpect(status().isNoContent());
     }
 }

--- a/src/test/java/com/glancy/backend/service/SearchRecordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/SearchRecordServiceTest.java
@@ -138,4 +138,29 @@ class SearchRecordServiceTest {
         List<SearchRecordResponse> list = searchRecordService.getRecords(user.getId());
         assertEquals(1, list.size());
     }
+
+    @Test
+    void testUnfavoriteRecord() {
+        User user = new User();
+        user.setUsername("fav");
+        user.setPassword("p");
+        user.setEmail("f@example.com");
+        user.setPhone("45");
+        userRepository.save(user);
+        user.setLastLoginAt(LocalDateTime.now());
+        userRepository.save(user);
+
+        SearchRecordRequest req = new SearchRecordRequest();
+        req.setTerm("hi");
+        req.setLanguage(Language.ENGLISH);
+        SearchRecordResponse resp = searchRecordService.saveRecord(user.getId(), req);
+
+        var record = searchRecordRepository.findById(resp.getId()).orElseThrow();
+        record.setFavorite(true);
+        searchRecordRepository.save(record);
+
+        searchRecordService.unfavoriteRecord(user.getId(), resp.getId());
+        var updated = searchRecordRepository.findById(resp.getId()).orElseThrow();
+        assertFalse(updated.getFavorite());
+    }
 }


### PR DESCRIPTION
## Summary
- add `favorite` field to `SearchRecord`
- support unfavoriting search records in the service and controller
- expose favorite status via `SearchRecordResponse`
- document new endpoint and update curl tests
- add unit tests for the new functionality

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_687e368404788332b99626150f804a00