### PR TITLE
[Fix] set content type for uploaded avatars

### DIFF
--- a/src/main/java/com/glancy/backend/service/AvatarStorageService.java
+++ b/src/main/java/com/glancy/backend/service/AvatarStorageService.java
@@ -67,7 +67,11 @@ public class AvatarStorageService {
             ext = original.substring(original.lastIndexOf('.'));
         }
         String objectName = avatarDir + UUID.randomUUID() + ext;
-        ossClient.putObject(bucket, objectName, file.getInputStream());
+        com.aliyun.oss.model.ObjectMetadata metadata = new com.aliyun.oss.model.ObjectMetadata();
+        if (file.getContentType() != null && !file.getContentType().isEmpty()) {
+            metadata.setContentType(file.getContentType());
+        }
+        ossClient.putObject(bucket, objectName, file.getInputStream(), metadata);
         return urlPrefix + objectName;
     }
 }


### PR DESCRIPTION
## Summary
- ensure uploaded avatars set proper content type when stored in OSS

## Testing
- `./mvnw -q test`


------
https://chatgpt.com/codex/tasks/task_e_6881c59c5cd08332aa1037cf20132434