### PR TITLE
[Feature] Add avatar storage strategy

### DIFF
--- a/scripts/curl-tests.sh
+++ b/scripts/curl-tests.sh
@@ -70,6 +70,9 @@ curl -i -H "Content-Type: application/json" \
 section "Get user profile"
 curl -i "$BASE_URL/api/profiles/user/1"
 
+section "Upload avatar"
+curl -i -F "file=@avatar.jpg" "$BASE_URL/api/users/1/avatar-file"
+
 section "Add search record"
 curl -i -H "Content-Type: application/json" \
     -d '{"term":"hello","language":"ENGLISH"}' \

--- a/src/main/java/com/glancy/backend/service/AvatarStorage.java
+++ b/src/main/java/com/glancy/backend/service/AvatarStorage.java
@@ -1,0 +1,14 @@
+package com.glancy.backend.service;
+
+import java.io.IOException;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * Strategy interface for storing avatar images.
+ */
+public interface AvatarStorage {
+    /**
+     * Upload the avatar file and return the accessible URL.
+     */
+    String upload(MultipartFile file) throws IOException;
+}

--- a/src/main/java/com/glancy/backend/service/OssAvatarStorage.java
+++ b/src/main/java/com/glancy/backend/service/OssAvatarStorage.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+
 import java.io.IOException;
 import java.util.UUID;
 
@@ -15,7 +16,7 @@ import java.util.UUID;
  * Handles uploading avatar images to Alibaba Cloud OSS.
  */
 @Service
-public class AvatarStorageService {
+public class OssAvatarStorage implements AvatarStorage {
     private final String endpoint;
     private final String bucket;
     private final String accessKeyId;
@@ -25,7 +26,7 @@ public class AvatarStorageService {
 
     private OSS ossClient;
 
-    public AvatarStorageService(
+    public OssAvatarStorage(
             @Value("${oss.endpoint}") String endpoint,
             @Value("${oss.bucket}") String bucket,
             @Value("${oss.access-key-id:}") String accessKeyId,

--- a/src/main/java/com/glancy/backend/service/UserService.java
+++ b/src/main/java/com/glancy/backend/service/UserService.java
@@ -18,6 +18,7 @@ import com.glancy.backend.dto.DailyActiveUserResponse;
 import com.glancy.backend.entity.User;
 import com.glancy.backend.entity.LoginDevice;
 import com.glancy.backend.entity.ThirdPartyAccount;
+import com.glancy.backend.service.AvatarStorage;
 import com.glancy.backend.repository.UserRepository;
 import com.glancy.backend.repository.LoginDeviceRepository;
 import com.glancy.backend.repository.ThirdPartyAccountRepository;
@@ -41,16 +42,16 @@ public class UserService {
     private final LoginDeviceRepository loginDeviceRepository;
     private final ThirdPartyAccountRepository thirdPartyAccountRepository;
     private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-    private final AvatarStorageService avatarStorageService;
+    private final AvatarStorage avatarStorage;
 
     public UserService(UserRepository userRepository,
                        LoginDeviceRepository loginDeviceRepository,
                        ThirdPartyAccountRepository thirdPartyAccountRepository,
-                       AvatarStorageService avatarStorageService) {
+                       AvatarStorage avatarStorage) {
         this.userRepository = userRepository;
         this.loginDeviceRepository = loginDeviceRepository;
         this.thirdPartyAccountRepository = thirdPartyAccountRepository;
-        this.avatarStorageService = avatarStorageService;
+        this.avatarStorage = avatarStorage;
     }
 
     /**
@@ -299,7 +300,7 @@ public class UserService {
     @Transactional
     public AvatarResponse uploadAvatar(Long userId, MultipartFile file) {
         try {
-            String url = avatarStorageService.upload(file);
+            String url = avatarStorage.upload(file);
             return updateAvatar(userId, url);
         } catch (IOException e) {
             log.error("Failed to upload avatar", e);

--- a/src/test/java/com/glancy/backend/service/OssAvatarStorageTest.java
+++ b/src/test/java/com/glancy/backend/service/OssAvatarStorageTest.java
@@ -1,0 +1,22 @@
+package com.glancy.backend.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Simple tests for OssAvatarStorage.
+ */
+class OssAvatarStorageTest {
+
+    @Test
+    void uploadWithoutClientThrows() {
+        OssAvatarStorage storage = new OssAvatarStorage(
+                "https://oss-cn-hangzhou.aliyuncs.com",
+                "bucket", "", "", "avatars/");
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "avatar.jpg", "image/jpeg", "data".getBytes());
+        assertThrows(IllegalStateException.class, () -> storage.upload(file));
+    }
+}

--- a/src/test/java/com/glancy/backend/service/UserServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/UserServiceTest.java
@@ -8,6 +8,7 @@ import com.glancy.backend.entity.User;
 import com.glancy.backend.entity.LoginDevice;
 import com.glancy.backend.repository.UserRepository;
 import com.glancy.backend.repository.LoginDeviceRepository;
+import com.glancy.backend.service.AvatarStorage;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -36,7 +37,7 @@ class UserServiceTest {
     @Autowired
     private LoginDeviceRepository loginDeviceRepository;
     @MockitoBean
-    private AvatarStorageService avatarStorageService;
+    private AvatarStorage avatarStorage;
 
     @BeforeAll
     static void loadEnv() {
@@ -239,7 +240,7 @@ class UserServiceTest {
         UserResponse resp = userService.register(req);
 
         MultipartFile file = mock(MultipartFile.class);
-        when(avatarStorageService.upload(file)).thenReturn("path/url.jpg");
+        when(avatarStorage.upload(file)).thenReturn("path/url.jpg");
 
         AvatarResponse result = userService.uploadAvatar(resp.getId(), file);
         assertEquals("path/url.jpg", result.getAvatar());


### PR DESCRIPTION
## Summary
- extract `AvatarStorage` interface and implement `OssAvatarStorage`
- inject the strategy in `UserService`
- add unit test for the storage implementation
- update curl script with avatar upload example

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_6881ce0f14a48332b4956bc805019908