### PR TITLE
[Feature] Add token-based interceptor

### DIFF
--- a/src/main/java/com/glancy/backend/config/TokenAuthenticationInterceptor.java
+++ b/src/main/java/com/glancy/backend/config/TokenAuthenticationInterceptor.java
@@ -1,0 +1,55 @@
+package com.glancy.backend.config;
+
+import com.glancy.backend.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.Map;
+
+/**
+ * Interceptor that validates the {@code X-USER-TOKEN} header for requests
+ * targeting user-specific endpoints.
+ */
+@Component
+public class TokenAuthenticationInterceptor implements HandlerInterceptor {
+    private final UserService userService;
+
+    public TokenAuthenticationInterceptor(UserService userService) {
+        this.userService = userService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String token = request.getHeader("X-USER-TOKEN");
+        if (token == null) {
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), "Missing X-USER-TOKEN header");
+            return false;
+        }
+
+        Map<String, String> pathVariables =
+                (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        String userIdStr = null;
+        if (pathVariables != null) {
+            userIdStr = pathVariables.get("userId");
+        }
+        if (userIdStr == null) {
+            userIdStr = request.getParameter("userId");
+        }
+        if (userIdStr == null) {
+            response.sendError(HttpStatus.BAD_REQUEST.value(), "Missing userId");
+            return false;
+        }
+        try {
+            Long userId = Long.valueOf(userIdStr);
+            userService.validateToken(userId, token);
+            return true;
+        } catch (Exception ex) {
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), "Invalid token");
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/glancy/backend/config/WebConfig.java
+++ b/src/main/java/com/glancy/backend/config/WebConfig.java
@@ -2,11 +2,21 @@ package com.glancy.backend.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.lang.NonNull;
 
+/**
+ * General web configuration including CORS and token authentication.
+ */
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    private final TokenAuthenticationInterceptor tokenAuthenticationInterceptor;
+
+    public WebConfig(TokenAuthenticationInterceptor tokenAuthenticationInterceptor) {
+        this.tokenAuthenticationInterceptor = tokenAuthenticationInterceptor;
+    }
 
     @Override
     public void addCorsMappings(@NonNull CorsRegistry registry) {
@@ -15,5 +25,11 @@ public class WebConfig implements WebMvcConfigurer {
             .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
             .allowedHeaders("*")
             .allowCredentials(true);
+    }
+
+    @Override
+    public void addInterceptors(@NonNull InterceptorRegistry registry) {
+        registry.addInterceptor(tokenAuthenticationInterceptor)
+            .addPathPatterns("/api/search-records/**", "/api/words");
     }
 }

--- a/src/main/java/com/glancy/backend/controller/SearchRecordController.java
+++ b/src/main/java/com/glancy/backend/controller/SearchRecordController.java
@@ -3,7 +3,6 @@ package com.glancy.backend.controller;
 import com.glancy.backend.dto.SearchRecordRequest;
 import com.glancy.backend.dto.SearchRecordResponse;
 import com.glancy.backend.service.SearchRecordService;
-import com.glancy.backend.service.UserService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,12 +18,9 @@ import java.util.List;
 @RequestMapping("/api/search-records")
 public class SearchRecordController {
     private final SearchRecordService searchRecordService;
-    private final UserService userService;
 
-    public SearchRecordController(SearchRecordService searchRecordService,
-                                  UserService userService) {
+    public SearchRecordController(SearchRecordService searchRecordService) {
         this.searchRecordService = searchRecordService;
-        this.userService = userService;
     }
 
     /**
@@ -35,7 +31,6 @@ public class SearchRecordController {
     public ResponseEntity<SearchRecordResponse> create(@PathVariable Long userId,
                                                        @RequestHeader("X-USER-TOKEN") String token,
                                                        @Valid @RequestBody SearchRecordRequest req) {
-        userService.validateToken(userId, token);
         SearchRecordResponse resp = searchRecordService.saveRecord(userId, req);
         return new ResponseEntity<>(resp, HttpStatus.CREATED);
     }
@@ -46,7 +41,6 @@ public class SearchRecordController {
     @GetMapping("/user/{userId}")
     public ResponseEntity<List<SearchRecordResponse>> list(@PathVariable Long userId,
                                                            @RequestHeader("X-USER-TOKEN") String token) {
-        userService.validateToken(userId, token);
         List<SearchRecordResponse> resp = searchRecordService.getRecords(userId);
         return ResponseEntity.ok(resp);
     }
@@ -57,7 +51,6 @@ public class SearchRecordController {
     @DeleteMapping("/user/{userId}")
     public ResponseEntity<Void> clear(@PathVariable Long userId,
                                       @RequestHeader("X-USER-TOKEN") String token) {
-        userService.validateToken(userId, token);
         searchRecordService.clearRecords(userId);
         return ResponseEntity.noContent().build();
     }
@@ -69,7 +62,6 @@ public class SearchRecordController {
     public ResponseEntity<SearchRecordResponse> favorite(@PathVariable Long userId,
                                                          @PathVariable Long recordId,
                                                          @RequestHeader("X-USER-TOKEN") String token) {
-        userService.validateToken(userId, token);
         SearchRecordResponse resp = searchRecordService.favoriteRecord(userId, recordId);
         return ResponseEntity.ok(resp);
     }
@@ -81,7 +73,6 @@ public class SearchRecordController {
     public ResponseEntity<Void> unfavorite(@PathVariable Long userId,
                                            @PathVariable Long recordId,
                                            @RequestHeader("X-USER-TOKEN") String token) {
-        userService.validateToken(userId, token);
         searchRecordService.unfavoriteRecord(userId, recordId);
         return ResponseEntity.noContent().build();
     }
@@ -93,7 +84,6 @@ public class SearchRecordController {
     public ResponseEntity<Void> delete(@PathVariable Long userId,
                                        @PathVariable Long recordId,
                                        @RequestHeader("X-USER-TOKEN") String token) {
-        userService.validateToken(userId, token);
         searchRecordService.deleteRecord(userId, recordId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/glancy/backend/controller/WordController.java
+++ b/src/main/java/com/glancy/backend/controller/WordController.java
@@ -6,7 +6,6 @@ import com.glancy.backend.entity.Language;
 import org.springframework.http.MediaType;
 import com.glancy.backend.service.WordService;
 import com.glancy.backend.service.SearchRecordService;
-import com.glancy.backend.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -23,14 +22,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class WordController {
     private final WordService wordService;
     private final SearchRecordService searchRecordService;
-    private final UserService userService;
 
     public WordController(WordService wordService,
-                          SearchRecordService searchRecordService,
-                          UserService userService) {
+                          SearchRecordService searchRecordService) {
         this.wordService = wordService;
         this.searchRecordService = searchRecordService;
-        this.userService = userService;
     }
 
     /**
@@ -41,7 +37,6 @@ public class WordController {
                                                 @RequestHeader("X-USER-TOKEN") String token,
                                                 @RequestParam String term,
                                                 @RequestParam Language language) {
-        userService.validateToken(userId, token);
         SearchRecordRequest req = new SearchRecordRequest();
         req.setTerm(term);
         req.setLanguage(language);

--- a/src/test/java/com/glancy/backend/config/TokenAuthenticationInterceptorTest.java
+++ b/src/test/java/com/glancy/backend/config/TokenAuthenticationInterceptorTest.java
@@ -1,0 +1,49 @@
+package com.glancy.backend.config;
+
+import com.glancy.backend.service.AlertService;
+import com.glancy.backend.service.SearchRecordService;
+import com.glancy.backend.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.http.MediaType;
+
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(com.glancy.backend.controller.SearchRecordController.class)
+@Import({SecurityConfig.class, WebConfig.class, TokenAuthenticationInterceptor.class})
+class TokenAuthenticationInterceptorTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @MockitoBean
+    private SearchRecordService searchRecordService;
+    @MockitoBean
+    private AlertService alertService;
+    @MockitoBean
+    private UserService userService;
+
+    @Test
+    void missingTokenReturnsUnauthorized() throws Exception {
+        mockMvc.perform(post("/api/search-records/user/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"term\":\"hello\",\"language\":\"ENGLISH\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void invalidTokenReturnsUnauthorized() throws Exception {
+        doThrow(new IllegalArgumentException("invalid")).when(userService).validateToken(1L, "bad");
+
+        mockMvc.perform(post("/api/search-records/user/1")
+                .header("X-USER-TOKEN", "bad")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"term\":\"hello\",\"language\":\"ENGLISH\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
@@ -24,7 +24,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(SearchRecordController.class)
-@Import(com.glancy.backend.config.SecurityConfig.class)
+@Import({com.glancy.backend.config.SecurityConfig.class,
+        com.glancy.backend.config.WebConfig.class,
+        com.glancy.backend.config.TokenAuthenticationInterceptor.class})
 class SearchRecordControllerTest {
     @MockitoBean
     private AlertService alertService;

--- a/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -24,7 +24,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 @WebMvcTest(WordController.class)
-@Import(com.glancy.backend.config.SecurityConfig.class)
+@Import({com.glancy.backend.config.SecurityConfig.class,
+        com.glancy.backend.config.WebConfig.class,
+        com.glancy.backend.config.TokenAuthenticationInterceptor.class})
 class WordControllerTest {
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
## Summary
- implement `TokenAuthenticationInterceptor` to validate `X-USER-TOKEN`
- configure interceptor via `WebConfig`
- remove token validation from controllers
- adjust unit tests and add `TokenAuthenticationInterceptorTest`

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68827a47870c83328a806026d5e01f05