### PR TITLE
[Feature] Add business exceptions and centralized handling

### DIFF
--- a/src/main/java/com/glancy/backend/controller/PortalController.java
+++ b/src/main/java/com/glancy/backend/controller/PortalController.java
@@ -112,11 +112,7 @@ public class PortalController {
         if (!loggingService.isTokenValid(token)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
-        try {
-            loggingService.setLogLevel(req.getLogger(), req.getLevel());
-        } catch (IllegalArgumentException ex) {
-            return ResponseEntity.badRequest().build();
-        }
+        loggingService.setLogLevel(req.getLogger(), req.getLevel());
         return ResponseEntity.ok().build();
     }
 
@@ -137,11 +133,7 @@ public class PortalController {
      */
     @GetMapping("/email-enabled")
     public ResponseEntity<Boolean> isEmailEnabled() {
-        try {
-            SystemParameterResponse resp = parameterService.getByName(EMAIL_PARAM);
-            return ResponseEntity.ok(Boolean.parseBoolean(resp.getValue()));
-        } catch (IllegalArgumentException ex) {
-            return ResponseEntity.ok(false);
-        }
+        SystemParameterResponse resp = parameterService.getByName(EMAIL_PARAM);
+        return ResponseEntity.ok(Boolean.parseBoolean(resp.getValue()));
     }
 }

--- a/src/main/java/com/glancy/backend/exception/BusinessException.java
+++ b/src/main/java/com/glancy/backend/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.glancy.backend.exception;
+
+/**
+ * Base class for business logic exceptions that indicate a recoverable
+ * issue triggered by invalid input or application state.
+ */
+public class BusinessException extends RuntimeException {
+    public BusinessException(String message) {
+        super(message);
+    }
+    public BusinessException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/glancy/backend/exception/DuplicateResourceException.java
+++ b/src/main/java/com/glancy/backend/exception/DuplicateResourceException.java
@@ -1,0 +1,10 @@
+package com.glancy.backend.exception;
+
+/**
+ * Thrown when attempting to create a resource that already exists.
+ */
+public class DuplicateResourceException extends BusinessException {
+    public DuplicateResourceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/glancy/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/glancy/backend/exception/GlobalExceptionHandler.java
@@ -10,6 +10,11 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 import com.glancy.backend.service.AlertService;
 
+import com.glancy.backend.exception.ResourceNotFoundException;
+import com.glancy.backend.exception.DuplicateResourceException;
+import com.glancy.backend.exception.InvalidRequestException;
+import com.glancy.backend.exception.BusinessException;
+
 /**
  * Handles application exceptions and logs them.
  */
@@ -23,15 +28,32 @@ public class GlobalExceptionHandler {
         this.alertService = alertService;
     }
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
-        log.error("Request resulted in error: {}", ex.getMessage(), ex);
-        alertService.sendAlert("Illegal argument", ex.getMessage());
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFound(ResourceNotFoundException ex) {
+        log.error("Resource not found: {}", ex.getMessage());
+        return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(DuplicateResourceException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicate(DuplicateResourceException ex) {
+        log.error("Duplicate resource: {}", ex.getMessage());
+        return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(InvalidRequestException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidRequest(InvalidRequestException ex) {
+        log.error("Invalid request: {}", ex.getMessage());
+        return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusiness(BusinessException ex) {
+        log.error("Business exception: {}", ex.getMessage());
         return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler({NoHandlerFoundException.class, NoResourceFoundException.class})
-    public ResponseEntity<ErrorResponse> handleNotFound(Exception ex) {
+    public ResponseEntity<ErrorResponse> handleSpringNotFound(Exception ex) {
         log.error("Resource not found: {}", ex.getMessage());
         return new ResponseEntity<>(new ErrorResponse("未找到资源"), HttpStatus.NOT_FOUND);
     }

--- a/src/main/java/com/glancy/backend/exception/InvalidRequestException.java
+++ b/src/main/java/com/glancy/backend/exception/InvalidRequestException.java
@@ -1,0 +1,11 @@
+package com.glancy.backend.exception;
+
+/**
+ * Thrown when a request violates business rules or contains invalid
+ * parameters.
+ */
+public class InvalidRequestException extends BusinessException {
+    public InvalidRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/glancy/backend/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/glancy/backend/exception/ResourceNotFoundException.java
@@ -1,0 +1,10 @@
+package com.glancy.backend.exception;
+
+/**
+ * Thrown when the requested entity does not exist.
+ */
+public class ResourceNotFoundException extends BusinessException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/glancy/backend/service/AlertRecipientService.java
+++ b/src/main/java/com/glancy/backend/service/AlertRecipientService.java
@@ -10,6 +10,8 @@ import com.glancy.backend.dto.AlertRecipientRequest;
 import com.glancy.backend.dto.AlertRecipientResponse;
 import com.glancy.backend.entity.AlertRecipient;
 import com.glancy.backend.repository.AlertRecipientRepository;
+import com.glancy.backend.exception.ResourceNotFoundException;
+import com.glancy.backend.exception.DuplicateResourceException;
 
 /**
  * Business logic for managing alert recipient email addresses.
@@ -46,9 +48,9 @@ public class AlertRecipientService {
     @Transactional
     public AlertRecipientResponse updateRecipient(Long id, AlertRecipientRequest request) {
         AlertRecipient recipient = repository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("收件人不存在"));
+                .orElseThrow(() -> new ResourceNotFoundException("收件人不存在"));
         if (!recipient.getEmail().equals(request.getEmail()) && repository.existsByEmail(request.getEmail())) {
-            throw new IllegalArgumentException("邮箱已存在");
+            throw new DuplicateResourceException("邮箱已存在");
         }
         recipient.setEmail(request.getEmail());
         AlertRecipient saved = repository.save(recipient);

--- a/src/main/java/com/glancy/backend/service/LoggingService.java
+++ b/src/main/java/com/glancy/backend/service/LoggingService.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.logging.LogLevel;
 import org.springframework.boot.logging.LoggingSystem;
 import org.springframework.stereotype.Service;
+import com.glancy.backend.exception.InvalidRequestException;
 
 /**
  * Allows changing the application's log level at runtime.
@@ -35,7 +36,7 @@ public class LoggingService {
         try {
             target = LogLevel.valueOf(level.toUpperCase());
         } catch (IllegalArgumentException ex) {
-            throw new IllegalArgumentException("Invalid log level: " + level);
+            throw new InvalidRequestException("Invalid log level: " + level);
         }
         loggingSystem.setLogLevel(loggerName, target);
     }

--- a/src/main/java/com/glancy/backend/service/NotificationService.java
+++ b/src/main/java/com/glancy/backend/service/NotificationService.java
@@ -14,6 +14,7 @@ import com.glancy.backend.entity.Notification;
 import com.glancy.backend.entity.User;
 import com.glancy.backend.repository.NotificationRepository;
 import com.glancy.backend.repository.UserRepository;
+import com.glancy.backend.exception.ResourceNotFoundException;
 
 /**
  * Business logic around creating and listing notifications that may
@@ -51,7 +52,7 @@ public class NotificationService {
     public NotificationResponse createUserNotification(Long userId, NotificationRequest request) {
         log.info("Creating notification for user {}: {}", userId, request.getMessage());
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("用户不存在"));
+                .orElseThrow(() -> new ResourceNotFoundException("用户不存在"));
         Notification notification = new Notification();
         notification.setMessage(request.getMessage());
         notification.setSystemLevel(false);

--- a/src/main/java/com/glancy/backend/service/SystemParameterService.java
+++ b/src/main/java/com/glancy/backend/service/SystemParameterService.java
@@ -10,6 +10,7 @@ import com.glancy.backend.dto.SystemParameterRequest;
 import com.glancy.backend.dto.SystemParameterResponse;
 import com.glancy.backend.entity.SystemParameter;
 import com.glancy.backend.repository.SystemParameterRepository;
+import com.glancy.backend.exception.ResourceNotFoundException;
 
 /**
  * Handles creation and retrieval of system parameters that can be
@@ -43,7 +44,7 @@ public class SystemParameterService {
     @Transactional(readOnly = true)
     public SystemParameterResponse getByName(String name) {
         SystemParameter param = parameterRepository.findByName(name)
-                .orElseThrow(() -> new IllegalArgumentException("参数不存在"));
+                .orElseThrow(() -> new ResourceNotFoundException("参数不存在"));
         return toResponse(param);
     }
 

--- a/src/main/java/com/glancy/backend/service/UserPreferenceService.java
+++ b/src/main/java/com/glancy/backend/service/UserPreferenceService.java
@@ -36,7 +36,7 @@ public class UserPreferenceService {
 
     private UserPreference createDefaultPreference(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("用户不存在"));
+                .orElseThrow(() -> new ResourceNotFoundException("用户不存在"));
         UserPreference pref = new UserPreference();
         pref.setUser(user);
         pref.setTheme(DEFAULT_THEME);
@@ -53,7 +53,7 @@ public class UserPreferenceService {
     public UserPreferenceResponse savePreference(Long userId, UserPreferenceRequest req) {
         log.info("Saving preferences for user {}", userId);
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("用户不存在"));
+                .orElseThrow(() -> new ResourceNotFoundException("用户不存在"));
         UserPreference pref = userPreferenceRepository.findByUserId(userId)
                 .orElse(new UserPreference());
         pref.setUser(user);

--- a/src/main/java/com/glancy/backend/service/UserProfileService.java
+++ b/src/main/java/com/glancy/backend/service/UserProfileService.java
@@ -10,6 +10,7 @@ import com.glancy.backend.entity.User;
 import com.glancy.backend.entity.UserProfile;
 import com.glancy.backend.repository.UserProfileRepository;
 import com.glancy.backend.repository.UserRepository;
+import com.glancy.backend.exception.ResourceNotFoundException;
 
 /**
  * Manage optional personal details for users.
@@ -33,7 +34,7 @@ public class UserProfileService {
     public UserProfileResponse saveProfile(Long userId, UserProfileRequest req) {
         log.info("Saving profile for user {}", userId);
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("用户不存在"));
+                .orElseThrow(() -> new ResourceNotFoundException("用户不存在"));
         UserProfile profile = userProfileRepository.findByUserId(userId)
                 .orElse(new UserProfile());
         profile.setUser(user);
@@ -53,7 +54,7 @@ public class UserProfileService {
     public UserProfileResponse getProfile(Long userId) {
         log.info("Fetching profile for user {}", userId);
         UserProfile profile = userProfileRepository.findByUserId(userId)
-                .orElseThrow(() -> new IllegalArgumentException("未找到用户配置"));
+                .orElseThrow(() -> new ResourceNotFoundException("未找到用户配置"));
         return toResponse(profile);
     }
 

--- a/src/test/java/com/glancy/backend/controller/PortalControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/PortalControllerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import com.glancy.backend.exception.InvalidRequestException;
 
 @WebMvcTest(PortalController.class)
 @Import(com.glancy.backend.config.SecurityConfig.class)
@@ -153,7 +154,7 @@ class PortalControllerTest {
         req.setLogger("com.test");
         req.setLevel("NOPE");
         when(loggingService.isTokenValid("secret")).thenReturn(true);
-        doThrow(new IllegalArgumentException("Invalid log level"))
+        doThrow(new InvalidRequestException("Invalid log level"))
                 .when(loggingService).setLogLevel("com.test", "NOPE");
 
         mockMvc.perform(post("/api/portal/log-level")

--- a/src/test/java/com/glancy/backend/service/SearchRecordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/SearchRecordServiceTest.java
@@ -17,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.time.LocalDateTime;
 
+import com.glancy.backend.exception.InvalidRequestException;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(properties = "search.limit.nonMember=2")
@@ -83,7 +85,7 @@ class SearchRecordServiceTest {
         req.setTerm("hi");
         req.setLanguage(Language.ENGLISH);
 
-        Exception ex = assertThrows(IllegalStateException.class,
+        Exception ex = assertThrows(InvalidRequestException.class,
                 () -> searchRecordService.saveRecord(user.getId(), req));
         assertEquals("用户未登录", ex.getMessage());
     }
@@ -111,7 +113,7 @@ class SearchRecordServiceTest {
 
         searchRecordService.saveRecord(user.getId(), req1);
         searchRecordService.saveRecord(user.getId(), req2);
-        Exception ex = assertThrows(IllegalStateException.class,
+        Exception ex = assertThrows(InvalidRequestException.class,
                 () -> searchRecordService.saveRecord(user.getId(), req3));
         assertEquals("非会员每天只能搜索2次", ex.getMessage());
     }

--- a/src/test/java/com/glancy/backend/service/UserServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/UserServiceTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.BeforeAll;
+import com.glancy.backend.exception.DuplicateResourceException;
 
 @SpringBootTest
 @Transactional
@@ -98,7 +99,7 @@ class UserServiceTest {
         req2.setEmail("b@example.com");
         req2.setPhone("102");
 
-        Exception ex = assertThrows(IllegalArgumentException.class, () -> {
+        Exception ex = assertThrows(DuplicateResourceException.class, () -> {
             userService.register(req2);
         });
         assertEquals("用户名已存在", ex.getMessage());
@@ -121,7 +122,7 @@ class UserServiceTest {
         req2.setEmail("a@example.com");
         req2.setPhone("112");
 
-        Exception ex = assertThrows(IllegalArgumentException.class, () -> {
+        Exception ex = assertThrows(DuplicateResourceException.class, () -> {
             userService.register(req2);
         });
         assertEquals("邮箱已被使用", ex.getMessage());
@@ -142,7 +143,7 @@ class UserServiceTest {
         req2.setEmail("p2@example.com");
         req2.setPhone("12345");
 
-        Exception ex = assertThrows(IllegalArgumentException.class, () -> {
+        Exception ex = assertThrows(DuplicateResourceException.class, () -> {
             userService.register(req2);
         });
         assertEquals("手机号已被使用", ex.getMessage());


### PR DESCRIPTION
## Summary
- introduce `BusinessException` base class and specific exceptions
- replace state/argument exceptions in services
- extend global exception handler with new cases
- simplify `PortalController` error flow
- adjust tests for the new exception types

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68827a4616388332a16cf5afbd8663a8