### PR TITLE
[Refactor] Introduce BaseEntity for shared fields

### DIFF
--- a/src/main/java/com/glancy/backend/entity/BaseEntity.java
+++ b/src/main/java/com/glancy/backend/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.glancy.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Common fields shared by multiple entities.
+ */
+@MappedSuperclass
+@Data
+@NoArgsConstructor
+public abstract class BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Boolean deleted = false;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/src/main/java/com/glancy/backend/entity/SearchRecord.java
+++ b/src/main/java/com/glancy/backend/entity/SearchRecord.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 
 /**
  * Record of a single dictionary search performed by a user.
@@ -13,10 +12,7 @@ import java.time.LocalDateTime;
 @Table(name = "search_records")
 @Data
 @NoArgsConstructor
-public class SearchRecord {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class SearchRecord extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
@@ -31,7 +27,4 @@ public class SearchRecord {
 
     @Column(nullable = false)
     private Boolean favorite = false;
-
-    @Column(nullable = false)
-    private LocalDateTime createdAt = LocalDateTime.now();
 }

--- a/src/main/java/com/glancy/backend/entity/User.java
+++ b/src/main/java/com/glancy/backend/entity/User.java
@@ -14,10 +14,7 @@ import java.time.LocalDateTime;
 @Table(name = "users")
 @Data
 @NoArgsConstructor
-public class User {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class User extends BaseEntity {
 
     @Column(nullable = false, unique = true, length = 50)
     private String username;
@@ -37,13 +34,7 @@ public class User {
     private String phone;
 
     @Column(nullable = false)
-    private Boolean deleted = false;
-
-    @Column(nullable = false)
     private Boolean member = false;
-
-    @Column(nullable = false)
-    private LocalDateTime createdAt = LocalDateTime.now();
 
     private LocalDateTime lastLoginAt;
 

--- a/src/main/java/com/glancy/backend/entity/Word.java
+++ b/src/main/java/com/glancy/backend/entity/Word.java
@@ -2,7 +2,6 @@ package com.glancy.backend.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,10 +13,7 @@ import java.util.List;
        uniqueConstraints = @UniqueConstraint(columnNames = {"term", "language"}))
 @Data
 @NoArgsConstructor
-public class Word {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Word extends BaseEntity {
 
     @Column(nullable = false, length = 100)
     private String term;
@@ -36,10 +32,4 @@ public class Word {
 
     @Column
     private String example;
-
-    @Column(nullable = false)
-    private Boolean deleted = false;
-
-    @Column(nullable = false)
-    private LocalDateTime createdAt = LocalDateTime.now();
 }


### PR DESCRIPTION
## Summary
- create `BaseEntity` with id, deleted and createdAt fields
- inherit from `BaseEntity` in `User`, `Word` and `SearchRecord`
- remove duplicated fields from these entities

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68831a1a35e08332b64dcf1f0c1528e2