### PR TITLE
[Feature] add DictionaryClient interface

### DIFF
--- a/src/main/java/com/glancy/backend/client/DeepSeekClient.java
+++ b/src/main/java/com/glancy/backend/client/DeepSeekClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.glancy.backend.dto.ChatCompletionResponse;
 import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.Language;
+import com.glancy.backend.client.DictionaryClient;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
@@ -23,8 +24,8 @@ import java.util.List;
 import java.util.Map;
 
 @Slf4j
-@Component
-public class DeepSeekClient {
+@Component("deepSeekClient")
+public class DeepSeekClient implements DictionaryClient {
     private final RestTemplate restTemplate;
     private final String baseUrl;
     private final String apiKey;
@@ -51,6 +52,7 @@ public class DeepSeekClient {
         }
     }
 
+    @Override
     public WordResponse fetchDefinition(String term, Language language) {
         log.info("Entering fetchDefinition with term '{}' and language {}", term, language);
         String url = UriComponentsBuilder.fromUriString(baseUrl)
@@ -94,6 +96,7 @@ public class DeepSeekClient {
         }
     }
 
+    @Override
     public byte[] fetchAudio(String term, Language language) {
         String url = UriComponentsBuilder.fromUriString(baseUrl)
                 .path("/words/audio")

--- a/src/main/java/com/glancy/backend/client/DictionaryClient.java
+++ b/src/main/java/com/glancy/backend/client/DictionaryClient.java
@@ -1,0 +1,20 @@
+package com.glancy.backend.client;
+
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+
+/**
+ * Common interface for third-party dictionary clients.
+ */
+public interface DictionaryClient {
+    /**
+     * Fetch the definition of the given term in the specified language.
+     */
+    WordResponse fetchDefinition(String term, Language language);
+
+    /**
+     * Fetch pronunciation audio for the given term and language.
+     * Implementations may throw UnsupportedOperationException if not supported.
+     */
+    byte[] fetchAudio(String term, Language language);
+}

--- a/src/main/java/com/glancy/backend/client/QianWenClient.java
+++ b/src/main/java/com/glancy/backend/client/QianWenClient.java
@@ -7,13 +7,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+import com.glancy.backend.client.DictionaryClient;
 
 /**
  * Client for interacting with the Qianwen API.
  */
 @Slf4j
-@Component
-public class QianWenClient {
+@Component("qianWenClient")
+public class QianWenClient implements DictionaryClient {
     private final RestTemplate restTemplate;
     private final String baseUrl;
 
@@ -23,6 +24,7 @@ public class QianWenClient {
         this.baseUrl = baseUrl;
     }
 
+    @Override
     public WordResponse fetchDefinition(String term, Language language) {
         log.info("Entering fetchDefinition with term '{}' and language {}", term, language);
         String url = UriComponentsBuilder.fromUriString(baseUrl)
@@ -31,5 +33,10 @@ public class QianWenClient {
                 .queryParam("language", language.name().toLowerCase())
                 .toUriString();
         return restTemplate.getForObject(url, WordResponse.class);
+    }
+
+    @Override
+    public byte[] fetchAudio(String term, Language language) {
+        throw new UnsupportedOperationException("Audio fetch not supported");
     }
 }

--- a/src/main/java/com/glancy/backend/service/WordService.java
+++ b/src/main/java/com/glancy/backend/service/WordService.java
@@ -2,7 +2,7 @@ package com.glancy.backend.service;
 
 import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.Language;
-import com.glancy.backend.client.DeepSeekClient;
+import com.glancy.backend.client.DictionaryClient;
 import com.glancy.backend.entity.DictionaryModel;
 import com.glancy.backend.repository.UserPreferenceRepository;
 import com.glancy.backend.entity.UserPreference;
@@ -11,6 +11,7 @@ import com.glancy.backend.service.dictionary.DictionaryStrategy;
 import com.glancy.backend.service.dictionary.QianWenStrategy;
 import java.util.HashMap;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Qualifier;
 import com.glancy.backend.entity.Word;
 import com.glancy.backend.repository.WordRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -23,17 +24,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 public class WordService {
-    private final DeepSeekClient deepSeekClient;
+    private final DictionaryClient dictionaryClient;
     private final WordRepository wordRepository;
     private final UserPreferenceRepository userPreferenceRepository;
     private final Map<DictionaryModel, DictionaryStrategy> strategies = new HashMap<>();
 
-    public WordService(DeepSeekClient deepSeekClient,
+    public WordService(@Qualifier("deepSeekClient") DictionaryClient dictionaryClient,
                        WordRepository wordRepository,
                        UserPreferenceRepository userPreferenceRepository,
                        DeepSeekStrategy deepSeekStrategy,
                        QianWenStrategy qianWenStrategy) {
-        this.deepSeekClient = deepSeekClient;
+        this.dictionaryClient = dictionaryClient;
         this.wordRepository = wordRepository;
         this.userPreferenceRepository = userPreferenceRepository;
         strategies.put(DictionaryModel.DEEPSEEK, deepSeekStrategy);
@@ -46,7 +47,7 @@ public class WordService {
     @Transactional(readOnly = true)
     public byte[] getAudio(String term, Language language) {
         log.info("Fetching audio for term '{}' in language {}", term, language);
-        return deepSeekClient.fetchAudio(term, language);
+        return dictionaryClient.fetchAudio(term, language);
     }
 
     @Transactional

--- a/src/main/java/com/glancy/backend/service/dictionary/DeepSeekStrategy.java
+++ b/src/main/java/com/glancy/backend/service/dictionary/DeepSeekStrategy.java
@@ -1,8 +1,9 @@
 package com.glancy.backend.service.dictionary;
 
-import com.glancy.backend.client.DeepSeekClient;
+import com.glancy.backend.client.DictionaryClient;
 import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.Language;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 /**
@@ -10,14 +11,14 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class DeepSeekStrategy implements DictionaryStrategy {
-    private final DeepSeekClient deepSeekClient;
+    private final DictionaryClient dictionaryClient;
 
-    public DeepSeekStrategy(DeepSeekClient deepSeekClient) {
-        this.deepSeekClient = deepSeekClient;
+    public DeepSeekStrategy(@Qualifier("deepSeekClient") DictionaryClient dictionaryClient) {
+        this.dictionaryClient = dictionaryClient;
     }
 
     @Override
     public WordResponse fetch(String term, Language language) {
-        return deepSeekClient.fetchDefinition(term, language);
+        return dictionaryClient.fetchDefinition(term, language);
     }
 }

--- a/src/main/java/com/glancy/backend/service/dictionary/QianWenStrategy.java
+++ b/src/main/java/com/glancy/backend/service/dictionary/QianWenStrategy.java
@@ -1,8 +1,9 @@
 package com.glancy.backend.service.dictionary;
 
-import com.glancy.backend.client.QianWenClient;
+import com.glancy.backend.client.DictionaryClient;
 import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.Language;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 /**
@@ -10,14 +11,14 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class QianWenStrategy implements DictionaryStrategy {
-    private final QianWenClient qianWenClient;
+    private final DictionaryClient dictionaryClient;
 
-    public QianWenStrategy(QianWenClient qianWenClient) {
-        this.qianWenClient = qianWenClient;
+    public QianWenStrategy(@Qualifier("qianWenClient") DictionaryClient dictionaryClient) {
+        this.dictionaryClient = dictionaryClient;
     }
 
     @Override
     public WordResponse fetch(String term, Language language) {
-        return qianWenClient.fetchDefinition(term, language);
+        return dictionaryClient.fetchDefinition(term, language);
     }
 }

--- a/src/test/java/com/glancy/backend/service/WordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/WordServiceTest.java
@@ -2,7 +2,7 @@ package com.glancy.backend.service;
 
 import com.glancy.backend.dto.WordResponse;
 import com.glancy.backend.entity.Language;
-import com.glancy.backend.client.DeepSeekClient;
+import com.glancy.backend.client.DictionaryClient;
 import com.glancy.backend.entity.Word;
 import com.glancy.backend.repository.WordRepository;
 import com.glancy.backend.repository.UserPreferenceRepository;
@@ -29,8 +29,8 @@ import static org.mockito.Mockito.*;
 class WordServiceTest {
     @Autowired
     private WordService wordService;
-    @MockitoBean
-    private DeepSeekClient deepSeekClient;
+    @MockitoBean(name = "deepSeekClient")
+    private DictionaryClient deepSeekClient;
     @MockitoBean
     private UserPreferenceRepository userPreferenceRepository;
     @MockitoBean


### PR DESCRIPTION
## Summary
- introduce `DictionaryClient` interface with `fetchDefinition` and `fetchAudio`
- implement the interface in `DeepSeekClient` and `QianWenClient`
- refactor `WordService` and dictionary strategies to depend on the interface via qualifiers
- update unit tests to mock the new interface

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68831a17e65083329a68958518e346b0