### PR TITLE
[Feature] add authenticated user resolver

### DIFF
--- a/src/main/java/com/glancy/backend/config/WebConfig.java
+++ b/src/main/java/com/glancy/backend/config/WebConfig.java
@@ -5,6 +5,10 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.lang.NonNull;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import java.util.List;
+
+import com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver;
 
 /**
  * General web configuration including CORS and token authentication.
@@ -13,9 +17,12 @@ import org.springframework.lang.NonNull;
 public class WebConfig implements WebMvcConfigurer {
 
     private final TokenAuthenticationInterceptor tokenAuthenticationInterceptor;
+    private final AuthenticatedUserArgumentResolver authenticatedUserArgumentResolver;
 
-    public WebConfig(TokenAuthenticationInterceptor tokenAuthenticationInterceptor) {
+    public WebConfig(TokenAuthenticationInterceptor tokenAuthenticationInterceptor,
+                     AuthenticatedUserArgumentResolver authenticatedUserArgumentResolver) {
         this.tokenAuthenticationInterceptor = tokenAuthenticationInterceptor;
+        this.authenticatedUserArgumentResolver = authenticatedUserArgumentResolver;
     }
 
     @Override
@@ -31,5 +38,10 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(@NonNull InterceptorRegistry registry) {
         registry.addInterceptor(tokenAuthenticationInterceptor)
             .addPathPatterns("/api/search-records/**", "/api/words");
+    }
+
+    @Override
+    public void addArgumentResolvers(@NonNull List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticatedUserArgumentResolver);
     }
 }

--- a/src/main/java/com/glancy/backend/config/auth/AuthenticatedUser.java
+++ b/src/main/java/com/glancy/backend/config/auth/AuthenticatedUser.java
@@ -1,0 +1,15 @@
+package com.glancy.backend.config.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation for controller method parameters that require
+ * authentication via user token.
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticatedUser {
+}

--- a/src/main/java/com/glancy/backend/config/auth/AuthenticatedUserArgumentResolver.java
+++ b/src/main/java/com/glancy/backend/config/auth/AuthenticatedUserArgumentResolver.java
@@ -1,0 +1,81 @@
+package com.glancy.backend.config.auth;
+
+import com.glancy.backend.entity.User;
+import com.glancy.backend.exception.InvalidRequestException;
+import com.glancy.backend.exception.UnauthorizedException;
+import com.glancy.backend.exception.BusinessException;
+import com.glancy.backend.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.lang.NonNull;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/**
+ * Resolves parameters annotated with {@link AuthenticatedUser} by validating
+ * the user token from request headers.
+ */
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthenticatedUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final UserService userService;
+
+    public AuthenticatedUserArgumentResolver(UserService userService) {
+        this.userService = userService;
+    }
+
+    @Override
+    public boolean supportsParameter(@NonNull MethodParameter parameter) {
+        if (!parameter.hasParameterAnnotation(AuthenticatedUser.class)) {
+            return false;
+        }
+        Class<?> type = parameter.getParameterType();
+        return User.class.isAssignableFrom(type) || Long.class.equals(type);
+    }
+
+    @Override
+    public Object resolveArgument(@NonNull MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  @NonNull NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String token = request.getHeader("X-USER-TOKEN");
+        if (token == null) {
+            throw new UnauthorizedException("Missing X-USER-TOKEN header");
+        }
+
+        Map<String, String> pathVars = (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        String userIdStr = null;
+        if (pathVars != null) {
+            userIdStr = pathVars.get("userId");
+            if (userIdStr == null) {
+                userIdStr = pathVars.get("id");
+            }
+        }
+        if (userIdStr == null) {
+            userIdStr = request.getParameter("userId");
+        }
+        if (userIdStr == null) {
+            throw new InvalidRequestException("Missing userId");
+        }
+        Long userId = Long.valueOf(userIdStr);
+        try {
+            userService.validateToken(userId, token);
+        } catch (BusinessException ex) {
+            throw new UnauthorizedException("Invalid token");
+        }
+
+        if (Long.class.equals(parameter.getParameterType())) {
+            return userId;
+        }
+        return userService.getUserRaw(userId);
+    }
+}

--- a/src/main/java/com/glancy/backend/controller/SearchRecordController.java
+++ b/src/main/java/com/glancy/backend/controller/SearchRecordController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import com.glancy.backend.config.auth.AuthenticatedUser;
 
 import java.util.List;
 
@@ -28,8 +29,7 @@ public class SearchRecordController {
      * 10 searches per day as enforced in the service layer.
      */
     @PostMapping("/user/{userId}")
-    public ResponseEntity<SearchRecordResponse> create(@PathVariable Long userId,
-                                                       @RequestHeader("X-USER-TOKEN") String token,
+    public ResponseEntity<SearchRecordResponse> create(@AuthenticatedUser Long userId,
                                                        @Valid @RequestBody SearchRecordRequest req) {
         SearchRecordResponse resp = searchRecordService.saveRecord(userId, req);
         return new ResponseEntity<>(resp, HttpStatus.CREATED);
@@ -39,8 +39,7 @@ public class SearchRecordController {
      * Get a user's search history ordered by latest first.
      */
     @GetMapping("/user/{userId}")
-    public ResponseEntity<List<SearchRecordResponse>> list(@PathVariable Long userId,
-                                                           @RequestHeader("X-USER-TOKEN") String token) {
+    public ResponseEntity<List<SearchRecordResponse>> list(@AuthenticatedUser Long userId) {
         List<SearchRecordResponse> resp = searchRecordService.getRecords(userId);
         return ResponseEntity.ok(resp);
     }
@@ -49,8 +48,7 @@ public class SearchRecordController {
      * Clear all search records for a user.
      */
     @DeleteMapping("/user/{userId}")
-    public ResponseEntity<Void> clear(@PathVariable Long userId,
-                                      @RequestHeader("X-USER-TOKEN") String token) {
+    public ResponseEntity<Void> clear(@AuthenticatedUser Long userId) {
         searchRecordService.clearRecords(userId);
         return ResponseEntity.noContent().build();
     }
@@ -59,9 +57,8 @@ public class SearchRecordController {
      * Mark a search record as favorite for the user.
      */
     @PostMapping("/user/{userId}/{recordId}/favorite")
-    public ResponseEntity<SearchRecordResponse> favorite(@PathVariable Long userId,
-                                                         @PathVariable Long recordId,
-                                                         @RequestHeader("X-USER-TOKEN") String token) {
+    public ResponseEntity<SearchRecordResponse> favorite(@AuthenticatedUser Long userId,
+                                                         @PathVariable Long recordId) {
         SearchRecordResponse resp = searchRecordService.favoriteRecord(userId, recordId);
         return ResponseEntity.ok(resp);
     }
@@ -70,9 +67,8 @@ public class SearchRecordController {
      * Cancel favorite for a specific search record of the user.
      */
     @DeleteMapping("/user/{userId}/{recordId}/favorite")
-    public ResponseEntity<Void> unfavorite(@PathVariable Long userId,
-                                           @PathVariable Long recordId,
-                                           @RequestHeader("X-USER-TOKEN") String token) {
+    public ResponseEntity<Void> unfavorite(@AuthenticatedUser Long userId,
+                                           @PathVariable Long recordId) {
         searchRecordService.unfavoriteRecord(userId, recordId);
         return ResponseEntity.noContent().build();
     }
@@ -81,9 +77,8 @@ public class SearchRecordController {
      * Delete a specific search record of a user.
      */
     @DeleteMapping("/user/{userId}/{recordId}")
-    public ResponseEntity<Void> delete(@PathVariable Long userId,
-                                       @PathVariable Long recordId,
-                                       @RequestHeader("X-USER-TOKEN") String token) {
+    public ResponseEntity<Void> delete(@AuthenticatedUser Long userId,
+                                       @PathVariable Long recordId) {
         searchRecordService.deleteRecord(userId, recordId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/glancy/backend/controller/UserController.java
+++ b/src/main/java/com/glancy/backend/controller/UserController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import com.glancy.backend.config.auth.AuthenticatedUser;
 
 import com.glancy.backend.dto.LoginRequest;
 import com.glancy.backend.dto.LoginResponse;
@@ -73,9 +74,8 @@ public class UserController {
      * Log out a user by clearing their login token.
      */
     @PostMapping("/{id}/logout")
-    public ResponseEntity<Void> logout(@PathVariable Long id,
-                                       @RequestHeader("X-USER-TOKEN") String token) {
-        userService.logout(id, token);
+    public ResponseEntity<Void> logout(@AuthenticatedUser User user) {
+        userService.logout(user.getId(), user.getLoginToken());
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/glancy/backend/controller/WordController.java
+++ b/src/main/java/com/glancy/backend/controller/WordController.java
@@ -8,10 +8,11 @@ import com.glancy.backend.service.WordService;
 import com.glancy.backend.service.SearchRecordService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import com.glancy.backend.config.auth.AuthenticatedUser;
+import com.glancy.backend.entity.User;
 
 /**
  * Provides dictionary lookup functionality. Each request also
@@ -33,8 +34,7 @@ public class WordController {
      * Look up a word definition and save the search record.
      */
     @GetMapping
-    public ResponseEntity<WordResponse> getWord(@RequestParam Long userId,
-                                                @RequestHeader("X-USER-TOKEN") String token,
+    public ResponseEntity<WordResponse> getWord(@AuthenticatedUser Long userId,
                                                 @RequestParam String term,
                                                 @RequestParam Language language) {
         SearchRecordRequest req = new SearchRecordRequest();

--- a/src/main/java/com/glancy/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/glancy/backend/exception/GlobalExceptionHandler.java
@@ -46,6 +46,12 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthorized(UnauthorizedException ex) {
+        log.error("Unauthorized access: {}", ex.getMessage());
+        return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.UNAUTHORIZED);
+    }
+
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ErrorResponse> handleBusiness(BusinessException ex) {
         log.error("Business exception: {}", ex.getMessage());

--- a/src/main/java/com/glancy/backend/exception/UnauthorizedException.java
+++ b/src/main/java/com/glancy/backend/exception/UnauthorizedException.java
@@ -1,0 +1,10 @@
+package com.glancy.backend.exception;
+
+/**
+ * Thrown when the request lacks valid authentication information.
+ */
+public class UnauthorizedException extends BusinessException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/glancy/backend/config/TokenAuthenticationInterceptorTest.java
+++ b/src/test/java/com/glancy/backend/config/TokenAuthenticationInterceptorTest.java
@@ -16,7 +16,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(com.glancy.backend.controller.SearchRecordController.class)
-@Import({SecurityConfig.class, WebConfig.class, TokenAuthenticationInterceptor.class})
+@Import({SecurityConfig.class, WebConfig.class, TokenAuthenticationInterceptor.class,
+        com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class})
 class TokenAuthenticationInterceptorTest {
 
     @Autowired

--- a/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/SearchRecordControllerTest.java
@@ -26,7 +26,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(SearchRecordController.class)
 @Import({com.glancy.backend.config.SecurityConfig.class,
         com.glancy.backend.config.WebConfig.class,
-        com.glancy.backend.config.TokenAuthenticationInterceptor.class})
+        com.glancy.backend.config.TokenAuthenticationInterceptor.class,
+        com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class})
 class SearchRecordControllerTest {
     @MockitoBean
     private AlertService alertService;

--- a/src/test/java/com/glancy/backend/controller/UserControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/UserControllerTest.java
@@ -23,7 +23,10 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
 @WebMvcTest(UserController.class)
-@Import(com.glancy.backend.config.SecurityConfig.class)
+@Import({com.glancy.backend.config.SecurityConfig.class,
+        com.glancy.backend.config.WebConfig.class,
+        com.glancy.backend.config.TokenAuthenticationInterceptor.class,
+        com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class})
 class UserControllerTest {
     @MockitoBean
     private AlertService alertService;

--- a/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -26,7 +26,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 @WebMvcTest(WordController.class)
 @Import({com.glancy.backend.config.SecurityConfig.class,
         com.glancy.backend.config.WebConfig.class,
-        com.glancy.backend.config.TokenAuthenticationInterceptor.class})
+        com.glancy.backend.config.TokenAuthenticationInterceptor.class,
+        com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class})
 class WordControllerTest {
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
## Summary
- add `@AuthenticatedUser` annotation and argument resolver
- register resolver in `WebConfig`
- refactor controllers to use the new annotation
- handle unauthorized exception globally
- adjust related tests for resolver behavior

## Testing
- `./mvnw test` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68831a20c2b08332a6f0d3a39421274e