### PR TITLE
[Refactor] centralize word parsing via parser service

### DIFF
--- a/src/main/java/com/glancy/backend/llm/config/LLMConfig.java
+++ b/src/main/java/com/glancy/backend/llm/config/LLMConfig.java
@@ -1,0 +1,16 @@
+package com.glancy.backend.llm.config;
+
+import java.util.Map;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "llm")
+public class LLMConfig {
+    private String defaultClient = "deepseek";
+    private double temperature = 0.7;
+    private Map<String, String> apiKeys;
+    private String promptPath = "prompts/english_to_chinese.txt";
+}

--- a/src/main/java/com/glancy/backend/llm/llm/LLMClient.java
+++ b/src/main/java/com/glancy/backend/llm/llm/LLMClient.java
@@ -1,0 +1,9 @@
+package com.glancy.backend.llm.llm;
+
+import com.glancy.backend.llm.model.ChatMessage;
+import java.util.List;
+
+public interface LLMClient {
+    String chat(List<ChatMessage> messages, double temperature);
+    String name();
+}

--- a/src/main/java/com/glancy/backend/llm/llm/LLMClientFactory.java
+++ b/src/main/java/com/glancy/backend/llm/llm/LLMClientFactory.java
@@ -1,0 +1,23 @@
+package com.glancy.backend.llm.llm;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LLMClientFactory {
+    private final Map<String, LLMClient> clientMap = new HashMap<>();
+
+    @Autowired
+    public LLMClientFactory(List<LLMClient> clients) {
+        for (LLMClient client : clients) {
+            clientMap.put(client.name(), client);
+        }
+    }
+
+    public LLMClient get(String name) {
+        return clientMap.get(name);
+    }
+}

--- a/src/main/java/com/glancy/backend/llm/llm/OpenAIClient.java
+++ b/src/main/java/com/glancy/backend/llm/llm/OpenAIClient.java
@@ -1,0 +1,76 @@
+package com.glancy.backend.llm.llm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.glancy.backend.dto.ChatCompletionResponse;
+import com.glancy.backend.llm.model.ChatMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class OpenAIClient implements LLMClient {
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final String baseUrl;
+    private final String apiKey;
+
+    public OpenAIClient(@Value("${thirdparty.openai.base-url:https://api.openai.com}") String baseUrl,
+                        @Value("${thirdparty.openai.api-key:}") String apiKey) {
+        this.baseUrl = baseUrl;
+        this.apiKey = apiKey;
+    }
+
+    @Override
+    public String name() {
+        return "openai";
+    }
+
+    @Override
+    public String chat(List<ChatMessage> messages, double temperature) {
+        String url = UriComponentsBuilder.fromUriString(baseUrl)
+                .path("/v1/chat/completions")
+                .toUriString();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        if (apiKey != null && !apiKey.isEmpty()) {
+            headers.setBearerAuth(apiKey);
+        }
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("model", "gpt-3.5-turbo");
+        body.put("temperature", temperature);
+        List<Map<String, String>> messageList = new ArrayList<>();
+        for (ChatMessage m : messages) {
+            messageList.add(Map.of("role", m.getRole(), "content", m.getContent()));
+        }
+        body.put("messages", messageList);
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(body, headers);
+        ResponseEntity<String> response = restTemplate.exchange(
+                url,
+                HttpMethod.POST,
+                entity,
+                String.class
+        );
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            ChatCompletionResponse chat = mapper.readValue(response.getBody(), ChatCompletionResponse.class);
+            return chat.getChoices().get(0).getMessage().getContent();
+        } catch (Exception e) {
+            log.warn("Failed to parse OpenAI response", e);
+            return "";
+        }
+    }
+}

--- a/src/main/java/com/glancy/backend/llm/model/ChatMessage.java
+++ b/src/main/java/com/glancy/backend/llm/model/ChatMessage.java
@@ -1,0 +1,11 @@
+package com.glancy.backend.llm.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ChatMessage {
+    private String role;
+    private String content;
+}

--- a/src/main/java/com/glancy/backend/llm/parser/JacksonWordResponseParser.java
+++ b/src/main/java/com/glancy/backend/llm/parser/JacksonWordResponseParser.java
@@ -1,0 +1,107 @@
+package com.glancy.backend.llm.parser;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+public class JacksonWordResponseParser implements WordResponseParser {
+    @Override
+    public WordResponse parse(String content, String term, Language language) {
+        String json = extractJson(content);
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            var node = mapper.readTree(json);
+            String id = node.path("id").isNull() ? null : node.path("id").asText();
+            String parsedTerm = node.path("term").asText(null);
+            if (parsedTerm == null || parsedTerm.isEmpty()) {
+                parsedTerm = node.path("entry").asText(term);
+            }
+            List<String> definitions = new ArrayList<>();
+            var defsNode = node.path("definitions");
+            if (defsNode.isArray()) {
+                defsNode.forEach(n -> {
+                    String part = n.path("partOfSpeech").asText();
+                    var meaningsNode = n.path("meanings");
+                    List<String> meanings = new ArrayList<>();
+                    if (meaningsNode.isArray()) {
+                        meaningsNode.forEach(m -> meanings.add(m.asText()));
+                    } else if (n.has("definition")) {
+                        meanings.add(n.path("definition").asText());
+                    }
+                    String combined = String.join("; ", meanings);
+                    if (!combined.isEmpty()) {
+                        definitions.add(part.isEmpty() ? combined : part + ": " + combined);
+                    }
+                });
+            } else if (defsNode.isTextual()) {
+                definitions.add(defsNode.asText());
+            }
+            String langStr = node.path("language").asText();
+            Language lang = language;
+            if (!langStr.isEmpty()) {
+                String upper = langStr.toUpperCase();
+                if (upper.contains("CHINESE")) {
+                    lang = Language.CHINESE;
+                } else if (upper.contains("ENGLISH")) {
+                    lang = Language.ENGLISH;
+                } else {
+                    try {
+                        lang = Language.valueOf(upper);
+                    } catch (Exception ignored) {
+                    }
+                }
+            }
+            String example = node.path("example").isNull() ? null : node.path("example").asText();
+            if ((example == null || example.isEmpty()) && defsNode.isArray()) {
+                for (var def : defsNode) {
+                    var exNode = def.path("examples");
+                    if (exNode.isArray() && exNode.size() > 0) {
+                        example = exNode.get(0).asText();
+                        break;
+                    }
+                }
+            }
+            String phonetic = node.path("phonetic").isNull() ? null : node.path("phonetic").asText();
+            if ((phonetic == null || phonetic.isEmpty())) {
+                var pronNode = node.path("pronunciations");
+                if (pronNode.isObject()) {
+                    var it = pronNode.fields();
+                    if (it.hasNext()) {
+                        phonetic = it.next().getValue().asText();
+                    }
+                }
+            }
+            return new WordResponse(id, parsedTerm, definitions, lang, example, phonetic);
+        } catch (Exception e) {
+            log.warn("Failed to parse word response", e);
+            return new WordResponse(null, term, new ArrayList<>(), language, null, null);
+        }
+    }
+
+    private String extractJson(String text) {
+        String trimmed = text.trim();
+        if (trimmed.startsWith("```")) {
+            int firstNewline = trimmed.indexOf('\n');
+            if (firstNewline != -1) {
+                trimmed = trimmed.substring(firstNewline + 1);
+            }
+            int lastFence = trimmed.lastIndexOf("```");
+            if (lastFence != -1) {
+                trimmed = trimmed.substring(0, lastFence);
+            }
+        }
+        int start = trimmed.indexOf('{');
+        int end = trimmed.lastIndexOf('}');
+        if (start != -1 && end != -1 && start < end) {
+            trimmed = trimmed.substring(start, end + 1);
+        }
+        return trimmed.trim();
+    }
+}

--- a/src/main/java/com/glancy/backend/llm/parser/WordResponseParser.java
+++ b/src/main/java/com/glancy/backend/llm/parser/WordResponseParser.java
@@ -1,0 +1,8 @@
+package com.glancy.backend.llm.parser;
+
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+
+public interface WordResponseParser {
+    WordResponse parse(String content, String term, Language language);
+}

--- a/src/main/java/com/glancy/backend/llm/prompt/PromptManager.java
+++ b/src/main/java/com/glancy/backend/llm/prompt/PromptManager.java
@@ -1,0 +1,5 @@
+package com.glancy.backend.llm.prompt;
+
+public interface PromptManager {
+    String loadPrompt(String path);
+}

--- a/src/main/java/com/glancy/backend/llm/prompt/PromptManagerImpl.java
+++ b/src/main/java/com/glancy/backend/llm/prompt/PromptManagerImpl.java
@@ -1,0 +1,18 @@
+package com.glancy.backend.llm.prompt;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PromptManagerImpl implements PromptManager {
+    @Override
+    public String loadPrompt(String path) {
+        try {
+            return Files.readString(Path.of("src/main/resources/" + path));
+        } catch (IOException e) {
+            throw new RuntimeException("Prompt load failed: " + path, e);
+        }
+    }
+}

--- a/src/main/java/com/glancy/backend/llm/search/SearchContentManager.java
+++ b/src/main/java/com/glancy/backend/llm/search/SearchContentManager.java
@@ -1,0 +1,5 @@
+package com.glancy.backend.llm.search;
+
+public interface SearchContentManager {
+    String normalize(String input);
+}

--- a/src/main/java/com/glancy/backend/llm/search/SearchContentManagerImpl.java
+++ b/src/main/java/com/glancy/backend/llm/search/SearchContentManagerImpl.java
@@ -1,0 +1,11 @@
+package com.glancy.backend.llm.search;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class SearchContentManagerImpl implements SearchContentManager {
+    @Override
+    public String normalize(String input) {
+        return input == null ? "" : input.trim().toLowerCase();
+    }
+}

--- a/src/main/java/com/glancy/backend/llm/service/WordSearcher.java
+++ b/src/main/java/com/glancy/backend/llm/service/WordSearcher.java
@@ -1,0 +1,8 @@
+package com.glancy.backend.llm.service;
+
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+
+public interface WordSearcher {
+    WordResponse search(String term, Language language, String clientName);
+}

--- a/src/main/java/com/glancy/backend/llm/service/WordSearcherImpl.java
+++ b/src/main/java/com/glancy/backend/llm/service/WordSearcherImpl.java
@@ -1,0 +1,51 @@
+package com.glancy.backend.llm.service;
+
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+import com.glancy.backend.llm.config.LLMConfig;
+import com.glancy.backend.llm.llm.LLMClient;
+import com.glancy.backend.llm.llm.LLMClientFactory;
+import com.glancy.backend.llm.model.ChatMessage;
+import com.glancy.backend.llm.prompt.PromptManager;
+import com.glancy.backend.llm.search.SearchContentManager;
+import com.glancy.backend.llm.parser.WordResponseParser;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+public class WordSearcherImpl implements WordSearcher {
+    private final LLMClientFactory clientFactory;
+    private final LLMConfig config;
+    private final PromptManager promptManager;
+    private final SearchContentManager searchContentManager;
+    private final WordResponseParser parser;
+
+    public WordSearcherImpl(LLMClientFactory clientFactory,
+                            LLMConfig config,
+                            PromptManager promptManager,
+                            SearchContentManager searchContentManager,
+                            WordResponseParser parser) {
+        this.clientFactory = clientFactory;
+        this.config = config;
+        this.promptManager = promptManager;
+        this.searchContentManager = searchContentManager;
+        this.parser = parser;
+    }
+
+    @Override
+    public WordResponse search(String term, Language language, String clientName) {
+        String cleanInput = searchContentManager.normalize(term);
+        String prompt = promptManager.loadPrompt(config.getPromptPath());
+        String name = clientName != null ? clientName : config.getDefaultClient();
+        LLMClient client = clientFactory.get(name);
+        List<ChatMessage> messages = new ArrayList<>();
+        messages.add(new ChatMessage("system", prompt));
+        messages.add(new ChatMessage("user", cleanInput));
+        String content = client.chat(messages, config.getTemperature());
+        return parser.parse(content, term, language);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,11 @@ search:
     limit:
         nonMember: 10
 
+llm:
+    default-client: deepseek
+    temperature: 0.7
+    prompt-path: prompts/english_to_chinese.txt
+
 thirdparty:
     deepseek:
         base-url: https://api.deepseek.com

--- a/src/test/java/com/glancy/backend/client/DeepSeekClientTest.java
+++ b/src/test/java/com/glancy/backend/client/DeepSeekClientTest.java
@@ -25,7 +25,7 @@ class DeepSeekClientTest {
     void setUp() {
         RestTemplate restTemplate = new RestTemplate();
         server = MockRestServiceServer.bindTo(restTemplate).build();
-        client = new DeepSeekClient(restTemplate, "http://mock", "key");
+        client = new DeepSeekClient(restTemplate, "http://mock", "key", new com.glancy.backend.llm.parser.JacksonWordResponseParser());
     }
 
     /**

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -24,3 +24,8 @@ oss:
   avatar-dir: avatars/
   access-key-id:
   access-key-secret:
+
+llm:
+  default-client: deepseek
+  temperature: 0.7
+  prompt-path: prompts/english_to_chinese.txt


### PR DESCRIPTION
## Summary
- add `WordResponseParser` interface and `JacksonWordResponseParser` implementation
- inject parser into `WordSearcherImpl` and `DeepSeekClient`
- simplify search logic by delegating parsing to the shared parser
- adjust `DeepSeekClientTest` for new constructor

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688469798f2c833297d5ff67bf4c83fa