### PR TITLE
[Fix] improve bad request handling

### DIFF
--- a/src/main/java/com/glancy/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/glancy/backend/exception/GlobalExceptionHandler.java
@@ -6,6 +6,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
@@ -47,6 +49,20 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleBusiness(BusinessException ex) {
         log.error("Business exception: {}", ex.getMessage());
         return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingParam(MissingServletRequestParameterException ex) {
+        log.error("Missing request parameter: {}", ex.getParameterName());
+        String msg = "Missing required parameter: " + ex.getParameterName();
+        return new ResponseEntity<>(new ErrorResponse(msg), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        log.error("Invalid parameter: {}", ex.getName());
+        String msg = "Invalid value for parameter: " + ex.getName();
+        return new ResponseEntity<>(new ErrorResponse(msg), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler({NoHandlerFoundException.class, NoResourceFoundException.class})

--- a/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -74,4 +74,37 @@ class WordControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk());
     }
+
+    /**
+     * 测试 testGetWordMissingTerm 接口
+     */
+    @Test
+    void testGetWordMissingTerm() throws Exception {
+        doNothing().when(userService).validateToken(1L, "tkn");
+
+        mockMvc.perform(get("/api/words")
+                        .param("userId", "1")
+                        .header("X-USER-TOKEN", "tkn")
+                        .param("language", "ENGLISH"))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Missing required parameter: term"));
+    }
+
+    /**
+     * 测试 testGetWordInvalidLanguage 接口
+     */
+    @Test
+    void testGetWordInvalidLanguage() throws Exception {
+        doNothing().when(userService).validateToken(1L, "tkn");
+
+        mockMvc.perform(get("/api/words")
+                        .param("userId", "1")
+                        .header("X-USER-TOKEN", "tkn")
+                        .param("term", "hello")
+                        .param("language", "INVALID"))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Invalid value for parameter: language"));
+    }
 }


### PR DESCRIPTION
## Summary
- add global handlers for missing or invalid request parameters
- test word lookup error responses

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68878a72af908332a16c0ea4951a42a0