### PR TITLE
[Feature] capture more LLM word details

### DIFF
--- a/src/main/java/com/glancy/backend/dto/WordResponse.java
+++ b/src/main/java/com/glancy/backend/dto/WordResponse.java
@@ -3,11 +3,13 @@ package com.glancy.backend.dto;
 import com.glancy.backend.entity.Language;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class WordResponse {
     private String id;
     private String term;
@@ -15,4 +17,9 @@ public class WordResponse {
     private Language language;
     private String example;
     private String phonetic;
+    private List<String> variations;
+    private List<String> synonyms;
+    private List<String> antonyms;
+    private List<String> related;
+    private List<String> phrases;
 }

--- a/src/main/java/com/glancy/backend/entity/Word.java
+++ b/src/main/java/com/glancy/backend/entity/Word.java
@@ -26,6 +26,31 @@ public class Word extends BaseEntity {
     @Column(name = "definition", nullable = false, columnDefinition = "TEXT")
     private List<String> definitions = new ArrayList<>();
 
+    @ElementCollection
+    @CollectionTable(name = "word_variations", joinColumns = @JoinColumn(name = "word_id"))
+    @Column(name = "variation", nullable = false, columnDefinition = "TEXT")
+    private List<String> variations = new ArrayList<>();
+
+    @ElementCollection
+    @CollectionTable(name = "word_synonyms", joinColumns = @JoinColumn(name = "word_id"))
+    @Column(name = "synonym", nullable = false, columnDefinition = "TEXT")
+    private List<String> synonyms = new ArrayList<>();
+
+    @ElementCollection
+    @CollectionTable(name = "word_antonyms", joinColumns = @JoinColumn(name = "word_id"))
+    @Column(name = "antonym", nullable = false, columnDefinition = "TEXT")
+    private List<String> antonyms = new ArrayList<>();
+
+    @ElementCollection
+    @CollectionTable(name = "word_related_terms", joinColumns = @JoinColumn(name = "word_id"))
+    @Column(name = "related_term", nullable = false, columnDefinition = "TEXT")
+    private List<String> related = new ArrayList<>();
+
+    @ElementCollection
+    @CollectionTable(name = "word_phrases", joinColumns = @JoinColumn(name = "word_id"))
+    @Column(name = "phrase", nullable = false, columnDefinition = "TEXT")
+    private List<String> phrases = new ArrayList<>();
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 10)
     private Language language;

--- a/src/main/java/com/glancy/backend/service/WordService.java
+++ b/src/main/java/com/glancy/backend/service/WordService.java
@@ -75,6 +75,11 @@ public class WordService {
         Language lang = resp.getLanguage() != null ? resp.getLanguage() : language;
         word.setLanguage(lang);
         word.setDefinitions(resp.getDefinitions());
+        word.setVariations(resp.getVariations());
+        word.setSynonyms(resp.getSynonyms());
+        word.setAntonyms(resp.getAntonyms());
+        word.setRelated(resp.getRelated());
+        word.setPhrases(resp.getPhrases());
         word.setExample(resp.getExample());
         word.setPhonetic(resp.getPhonetic());
         log.info("Persisting new word '{}' with language {}", term, lang);
@@ -85,7 +90,16 @@ public class WordService {
     }
 
     private WordResponse toResponse(Word word) {
-        return new WordResponse(String.valueOf(word.getId()), word.getTerm(), word.getDefinitions(),
-                word.getLanguage(), word.getExample(), word.getPhonetic());
+        return new WordResponse(String.valueOf(word.getId()),
+                word.getTerm(),
+                word.getDefinitions(),
+                word.getLanguage(),
+                word.getExample(),
+                word.getPhonetic(),
+                word.getVariations(),
+                word.getSynonyms(),
+                word.getAntonyms(),
+                word.getRelated(),
+                word.getPhrases());
     }
 }

--- a/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -42,7 +42,8 @@ class WordControllerTest {
      */
     @Test
     void testGetWord() throws Exception {
-        WordResponse resp = new WordResponse("1", "hello", List.of("g"), Language.ENGLISH, "ex", "həˈloʊ");
+        WordResponse resp = new WordResponse("1", "hello", List.of("g"), Language.ENGLISH,
+                "ex", "həˈloʊ", List.of(), List.of(), List.of(), List.of(), List.of());
         when(wordService.findWordForUser(eq(1L), eq("hello"), eq(Language.ENGLISH))).thenReturn(resp);
 
         doNothing().when(userService).validateToken(1L, "tkn");

--- a/src/test/java/com/glancy/backend/llm/parser/JacksonWordResponseParserTest.java
+++ b/src/test/java/com/glancy/backend/llm/parser/JacksonWordResponseParserTest.java
@@ -35,5 +35,7 @@ class JacksonWordResponseParserTest {
         assertEquals("glow", resp.getTerm());
         assertFalse(resp.getDefinitions().isEmpty());
         assertNotNull(resp.getPhonetic());
+        assertTrue(resp.getVariations().isEmpty());
+        assertTrue(resp.getPhrases().isEmpty());
     }
 }


### PR DESCRIPTION
## Summary
- extend `WordResponse` to include variations, synonyms, antonyms, related terms and phrases
- persist these fields on `Word` entity
- parse additional details in `JacksonWordResponseParser`
- expose new data in `WordService`
- adjust controller and parser tests

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688794acc0888332bba5f9e97b181344