### PR TITLE
[Fix] Update search history timestamp

### DIFF
--- a/src/main/java/com/glancy/backend/service/SearchRecordService.java
+++ b/src/main/java/com/glancy/backend/service/SearchRecordService.java
@@ -62,7 +62,9 @@ public class SearchRecordService {
                 .findTopByUserIdAndTermAndLanguageOrderByCreatedAtDesc(userId,
                         request.getTerm(), request.getLanguage());
         if (existing != null) {
-            return searchRecordMapper.toResponse(existing);
+            existing.setCreatedAt(LocalDateTime.now());
+            SearchRecord updated = searchRecordRepository.save(existing);
+            return searchRecordMapper.toResponse(updated);
         }
 
         if (Boolean.FALSE.equals(user.getMember())) {

--- a/src/test/java/com/glancy/backend/service/SearchRecordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/SearchRecordServiceTest.java
@@ -160,7 +160,9 @@ class SearchRecordServiceTest {
         SearchRecordResponse second = searchRecordService.saveRecord(user.getId(), req);
 
         assertEquals(first.getId(), second.getId());
+        assertTrue(second.getCreatedAt().isAfter(first.getCreatedAt()));
         List<SearchRecordResponse> list = searchRecordService.getRecords(user.getId());
         assertEquals(1, list.size());
+        assertEquals(second.getCreatedAt(), list.get(0).getCreatedAt());
     }
 }


### PR DESCRIPTION
## Summary
- refresh `createdAt` when a user searches the same term again
- assert timestamp updates for repeated searches

## Testing
- `./mvnw -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6887a3a3e7a88332b2306d03895eec42