### PR TITLE
[Feature] Add default user profile creation

### DIFF
--- a/src/main/java/com/glancy/backend/service/UserService.java
+++ b/src/main/java/com/glancy/backend/service/UserService.java
@@ -20,6 +20,8 @@ import com.glancy.backend.entity.ThirdPartyAccount;
 import com.glancy.backend.repository.UserRepository;
 import com.glancy.backend.repository.LoginDeviceRepository;
 import com.glancy.backend.repository.ThirdPartyAccountRepository;
+import com.glancy.backend.service.UserProfileService;
+import com.glancy.backend.service.AvatarStorage;
 import com.glancy.backend.exception.ResourceNotFoundException;
 import com.glancy.backend.exception.DuplicateResourceException;
 import com.glancy.backend.exception.InvalidRequestException;
@@ -43,15 +45,18 @@ public class UserService {
     private final ThirdPartyAccountRepository thirdPartyAccountRepository;
     private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
     private final AvatarStorage avatarStorage;
+    private final UserProfileService userProfileService;
 
     public UserService(UserRepository userRepository,
                        LoginDeviceRepository loginDeviceRepository,
                        ThirdPartyAccountRepository thirdPartyAccountRepository,
-                       AvatarStorage avatarStorage) {
+                       AvatarStorage avatarStorage,
+                       UserProfileService userProfileService) {
         this.userRepository = userRepository;
         this.loginDeviceRepository = loginDeviceRepository;
         this.thirdPartyAccountRepository = thirdPartyAccountRepository;
         this.avatarStorage = avatarStorage;
+        this.userProfileService = userProfileService;
     }
 
     /**
@@ -79,6 +84,7 @@ public class UserService {
         user.setAvatar(req.getAvatar());
         user.setPhone(req.getPhone());
         User saved = userRepository.save(user);
+        userProfileService.initProfile(saved.getId());
         return new UserResponse(saved.getId(), saved.getUsername(), saved.getEmail(),
                 saved.getAvatar(), saved.getPhone());
     }

--- a/src/test/java/com/glancy/backend/service/UserProfileServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/UserProfileServiceTest.java
@@ -68,4 +68,22 @@ class UserProfileServiceTest {
         assertEquals(saved.getId(), fetched.getId());
         assertEquals("dev", fetched.getJob());
     }
+
+    /**
+     * Return default profile when none exists.
+     */
+    @Test
+    void testDefaultProfileWhenMissing() {
+        User user = new User();
+        user.setUsername("p2");
+        user.setPassword("pass");
+        user.setEmail("p2@example.com");
+        user.setPhone("112");
+        userRepository.save(user);
+
+        UserProfileResponse fetched = userProfileService.getProfile(user.getId());
+        assertNull(fetched.getId());
+        assertNull(fetched.getAge());
+        assertEquals(user.getId(), fetched.getUserId());
+    }
 }

--- a/src/test/java/com/glancy/backend/service/UserServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/UserServiceTest.java
@@ -8,6 +8,7 @@ import com.glancy.backend.entity.User;
 import com.glancy.backend.entity.LoginDevice;
 import com.glancy.backend.repository.UserRepository;
 import com.glancy.backend.repository.LoginDeviceRepository;
+import com.glancy.backend.repository.UserProfileRepository;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -36,6 +37,8 @@ class UserServiceTest {
     private UserRepository userRepository;
     @Autowired
     private LoginDeviceRepository loginDeviceRepository;
+    @Autowired
+    private UserProfileRepository userProfileRepository;
     @MockitoBean
     private AvatarStorage avatarStorage;
 
@@ -316,5 +319,20 @@ class UserServiceTest {
         userService.removeMembership(resp.getId());
         User user2 = userRepository.findById(resp.getId()).orElseThrow();
         assertFalse(user2.getMember());
+    }
+
+    /**
+     * Ensure a default profile is created on registration.
+     */
+    @Test
+    void testDefaultProfileOnRegister() {
+        UserRegistrationRequest req = new UserRegistrationRequest();
+        req.setUsername("pro1");
+        req.setPassword("pass");
+        req.setEmail("p1@example.com");
+        req.setPhone("301");
+        UserResponse resp = userService.register(req);
+
+        assertTrue(userProfileRepository.findByUserId(resp.getId()).isPresent());
     }
 }


### PR DESCRIPTION
## Summary
- ensure user profile is initialized on registration
- return a default profile when none exists
- test default profile creation and fallback behaviour

## Testing
- `./mvnw test -q` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6888628352a48332b46186727dac7377