### PR TITLE
[Fix] make OSS avatar uploads public

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Glancy Backend is a Spring Boot service that powers the Glancy dictionary applic
 Ensure the MySQL server provides SSL certificates trusted by the JVM. Configure the truststore if necessary when running with `useSSL=true`.
 6. Properties under `search.limit` and `oss` are bound to `SearchProperties` and `OssProperties`.
    `search.limit.nonMember` controls the daily search limit for non-members (default `10`).
+   `oss.public-read` determines if uploaded avatars are publicly accessible (default `true`).
 
 ## Database Initialization
 

--- a/src/main/java/com/glancy/backend/config/OssProperties.java
+++ b/src/main/java/com/glancy/backend/config/OssProperties.java
@@ -11,4 +11,8 @@ public class OssProperties {
     private String accessKeyId;
     private String accessKeySecret;
     private String avatarDir = "avatars/";
+    /**
+     * Whether uploaded objects should be publicly readable.
+     */
+    private boolean publicRead = true;
 }

--- a/src/main/java/com/glancy/backend/service/OssAvatarStorage.java
+++ b/src/main/java/com/glancy/backend/service/OssAvatarStorage.java
@@ -2,6 +2,7 @@ package com.glancy.backend.service;
 
 import com.aliyun.oss.OSS;
 import com.aliyun.oss.OSSClientBuilder;
+import com.aliyun.oss.model.CannedAccessControlList;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import com.glancy.backend.config.OssProperties;
@@ -24,6 +25,7 @@ public class OssAvatarStorage implements AvatarStorage {
     private final String accessKeyId;
     private final String accessKeySecret;
     private final String avatarDir;
+    private final boolean publicRead;
     private String urlPrefix;
 
     private OSS ossClient;
@@ -34,6 +36,7 @@ public class OssAvatarStorage implements AvatarStorage {
         this.accessKeyId = properties.getAccessKeyId();
         this.accessKeySecret = properties.getAccessKeySecret();
         this.avatarDir = properties.getAvatarDir();
+        this.publicRead = properties.isPublicRead();
         this.urlPrefix = String.format("https://%s.%s/", bucket, removeProtocol(endpoint));
     }
 
@@ -80,6 +83,9 @@ public class OssAvatarStorage implements AvatarStorage {
         }
         String objectName = avatarDir + UUID.randomUUID() + ext;
         ossClient.putObject(bucket, objectName, file.getInputStream());
+        if (publicRead) {
+            ossClient.setObjectAcl(bucket, objectName, CannedAccessControlList.PublicRead);
+        }
         return urlPrefix + objectName;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,5 +49,6 @@ oss:
     endpoint: https://oss-cn-beijing.aliyuncs.com
     bucket: glancy-avatar-bucket
     avatar-dir: avatars/
+    public-read: true
     access-key-id: ${OSS_ACCESS_KEY_ID:}
     access-key-secret: ${OSS_ACCESS_KEY_SECRET:}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -20,6 +20,7 @@ oss:
   endpoint: https://oss-cn-beijing.aliyuncs.com
   bucket: glancy-avatar-bucket
   avatar-dir: avatars/
+  public-read: true
   access-key-id:
   access-key-secret:
 


### PR DESCRIPTION
## Summary
- allow public-read ACL for uploaded avatars
- document `oss.public-read` property

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688884ac9ed083329900663252d198b3