### PR TITLE
[Fix] Resolve OSS mock compilation

### DIFF
--- a/src/test/java/com/glancy/backend/service/OssAvatarStorageTest.java
+++ b/src/test/java/com/glancy/backend/service/OssAvatarStorageTest.java
@@ -50,9 +50,8 @@ class OssAvatarStorageTest {
         OssAvatarStorage storage = new OssAvatarStorage(props);
 
         OSS client = mock(OSS.class);
-        when(client.putObject(eq("bucket"), anyString(), any())).thenReturn(null);
+        when(client.putObject(eq("bucket"), anyString(), any(java.io.InputStream.class))).thenReturn(null);
         OSSException ex = new OSSException("AccessDenied");
-        ex.setErrorCode("AccessDenied");
         doThrow(ex).when(client).setObjectAcl(eq("bucket"), anyString(), eq(CannedAccessControlList.PublicRead));
 
         var field = OssAvatarStorage.class.getDeclaredField("ossClient");


### PR DESCRIPTION
## Summary
- ensure OssAvatarStorageTest mocks use explicit InputStream matcher
- remove unsupported error code setting

## Testing
- `./mvnw -q test` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6888f8ace1c083328b85333d215f15e2