### PR TITLE
[Fix] configure upload size and handle oversized avatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Ensure the MySQL server provides SSL certificates trusted by the JVM. Configure 
    `oss.signed-url-expiration-minutes` sets the lifetime of presigned URLs when objects are private (default `1440`).
    If your bucket policy forbids changing object ACLs, either disable this option
    or configure the bucket itself for public read access.
+   `spring.servlet.multipart.max-file-size` controls the maximum upload size for avatars.
+   Update your Nginx proxy with a matching `client_max_body_size` to avoid 413 errors.
 
 ## Database Initialization
 

--- a/src/main/java/com/glancy/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/glancy/backend/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
@@ -63,6 +64,12 @@ public class GlobalExceptionHandler {
         log.error("Invalid parameter: {}", ex.getName());
         String msg = "Invalid value for parameter: " + ex.getName();
         return new ResponseEntity<>(new ErrorResponse(msg), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> handleMaxSize(MaxUploadSizeExceededException ex) {
+        log.error("File upload too large: {}", ex.getMessage());
+        return new ResponseEntity<>(new ErrorResponse("上传文件过大"), HttpStatus.PAYLOAD_TOO_LARGE);
     }
 
     @ExceptionHandler({NoHandlerFoundException.class, NoResourceFoundException.class})

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,11 @@ spring:
         password: ${DB_PASSWORD}
         driver-class-name: com.mysql.cj.jdbc.Driver
 
+    servlet:
+        multipart:
+            max-file-size: 5MB
+            max-request-size: 5MB
+
     jpa:
         hibernate:
             ddl-auto: update

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,6 +4,10 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 5MB
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
## Summary
- allow larger avatar uploads by configuring `spring.servlet.multipart`
- add handler for `MaxUploadSizeExceededException`
- document how to avoid 413 errors in README

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6888fceba9d48332ac916380c8786ddc