### PR TITLE
[Feature] Add STS token support for OSS signed URLs

### DIFF
--- a/src/main/java/com/glancy/backend/config/OssProperties.java
+++ b/src/main/java/com/glancy/backend/config/OssProperties.java
@@ -10,6 +10,10 @@ public class OssProperties {
     private String bucket;
     private String accessKeyId;
     private String accessKeySecret;
+    /**
+     * Optional security token when using STS temporary credentials.
+     */
+    private String securityToken;
     private String avatarDir = "avatars/";
     /**
      * Whether uploaded objects should be publicly readable.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,3 +59,4 @@ oss:
     verify-location: true
     access-key-id: ${OSS_ACCESS_KEY_ID:}
     access-key-secret: ${OSS_ACCESS_KEY_SECRET:}
+    security-token: ${OSS_SECURITY_TOKEN:}


### PR DESCRIPTION
## Summary
- allow passing a security token for OSS operations
- include `security-token` property in `application.yml`
- create OSS client with STS credentials when token is present
- append token when generating presigned URLs
- test presigned URL generation with security token

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688906c296dc8332b5c19c3a4cfa9dd6