### PR TITLE
[Fix] STS token query parameter for OSS

### DIFF
--- a/src/main/java/com/glancy/backend/service/OssAvatarStorage.java
+++ b/src/main/java/com/glancy/backend/service/OssAvatarStorage.java
@@ -138,16 +138,13 @@ public class OssAvatarStorage implements AvatarStorage {
     private String generatePresignedUrl(String objectName) {
         Date expiration = new Date(System.currentTimeMillis()
                 + Duration.ofMinutes(signedUrlExpirationMinutes).toMillis());
-        URL url;
+        GeneratePresignedUrlRequest req =
+                new GeneratePresignedUrlRequest(bucket, objectName, HttpMethod.GET);
+        req.setExpiration(expiration);
         if (securityToken != null && !securityToken.isEmpty()) {
-            GeneratePresignedUrlRequest req =
-                    new GeneratePresignedUrlRequest(bucket, objectName, HttpMethod.GET);
-            req.setExpiration(expiration);
-            req.setSecurityToken(securityToken);
-            url = ossClient.generatePresignedUrl(req);
-        } else {
-            url = ossClient.generatePresignedUrl(bucket, objectName, expiration);
+            req.addQueryParameter("security-token", securityToken);
         }
+        URL url = ossClient.generatePresignedUrl(req);
         return url.toString();
     }
 


### PR DESCRIPTION
## Summary
- handle STS token when generating presigned URLs

## Testing
- `./mvnw -q -DskipTests=false test` *(failed: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68890a59523483329602699b908a6e7b