### PR TITLE
[Feature] Log returned avatar URLs

### DIFF
--- a/src/main/java/com/glancy/backend/service/OssAvatarStorage.java
+++ b/src/main/java/com/glancy/backend/service/OssAvatarStorage.java
@@ -111,10 +111,14 @@ public class OssAvatarStorage implements AvatarStorage {
         String objectName = avatarDir + UUID.randomUUID() + ext;
         ossClient.putObject(bucket, objectName, file.getInputStream());
         boolean isPublic = setPublicReadAcl(objectName);
+        String url;
         if (isPublic) {
-            return urlPrefix + objectName;
+            url = urlPrefix + objectName;
+        } else {
+            url = generatePresignedUrl(objectName);
         }
-        return generatePresignedUrl(objectName);
+        log.info("Avatar stored as {}. URL returned: {}", objectName, url);
+        return url;
     }
 
     /**
@@ -145,7 +149,9 @@ public class OssAvatarStorage implements AvatarStorage {
             req.addQueryParameter("security-token", securityToken);
         }
         URL url = ossClient.generatePresignedUrl(req);
-        return url.toString();
+        String result = url.toString();
+        log.info("Generated presigned URL: {}", result);
+        return result;
     }
 
     private static String removeProtocol(String url) {


### PR DESCRIPTION
## Summary
- log the final avatar URL in `OssAvatarStorage.upload`
- log generated presigned URLs

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6889a959d1188332b9a0ecad36c67e16