### PR TITLE
[Feature] add Doubao client and LLM model API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Glancy Backend is a Spring Boot service that powers the Glancy dictionary applic
 ## Setup
 
 1. Clone this repository.
-2. Create a `.env` file with `DB_PASSWORD` and `thirdparty.deepseek.api-key` values.
+2. Create a `.env` file with `DB_PASSWORD`, `thirdparty.deepseek.api-key`, and `thirdparty.doubao.api-key` values.
 3. Ensure MySQL is running with a database named `glancy_db`, matching credentials, and SSL certificates configured as `useSSL=true` requires.
 4. Use the `local` Spring profile if SSL is unavailable: `./mvnw spring-boot:run -Dspring.profiles.active=local`.
 5. Configure optional API base URLs in `application.yml` under the `thirdparty` section.

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,11 @@
                         <artifactId>aliyun-sdk-oss</artifactId>
                         <version>3.18.2</version>
                 </dependency>
+                <dependency>
+                        <groupId>com.volcengine</groupId>
+                        <artifactId>volcengine-java-sdk-ark-runtime</artifactId>
+                        <version>LATEST</version>
+                </dependency>
         </dependencies>
 
     <build>

--- a/scripts/curl-tests.sh
+++ b/scripts/curl-tests.sh
@@ -97,3 +97,7 @@ section "Clear search records"
 curl -i -X DELETE "$BASE_URL/api/search-records/user/1"
 
 
+
+section "List LLM models"
+curl -i "$BASE_URL/api/llm/models"
+

--- a/src/main/java/com/glancy/backend/GlancyBackendApplication.java
+++ b/src/main/java/com/glancy/backend/GlancyBackendApplication.java
@@ -29,6 +29,10 @@ public class GlancyBackendApplication {
         if (deepseekKey != null) {
             System.setProperty("thirdparty.deepseek.api-key", deepseekKey);
         }
+        String doubaoKey = dotenv.get("thirdparty.doubao.api-key");
+        if (doubaoKey != null) {
+            System.setProperty("thirdparty.doubao.api-key", doubaoKey);
+        }
         String ossKey = dotenv.get("OSS_ACCESS_KEY_ID");
         if (ossKey != null) {
             System.setProperty("OSS_ACCESS_KEY_ID", ossKey);

--- a/src/main/java/com/glancy/backend/client/DoubaoClient.java
+++ b/src/main/java/com/glancy/backend/client/DoubaoClient.java
@@ -1,0 +1,65 @@
+package com.glancy.backend.client;
+
+import com.glancy.backend.llm.llm.LLMClient;
+import com.glancy.backend.llm.model.ChatMessage;
+import com.glancy.backend.entity.LlmModel;
+import com.volcengine.ark.runtime.model.completion.chat.ChatCompletionRequest;
+import com.volcengine.ark.runtime.model.completion.chat.ChatCompletionResponse;
+import com.volcengine.ark.runtime.model.completion.chat.ChatMessageRole;
+import com.volcengine.ark.runtime.service.ArkService;
+import jakarta.annotation.PreDestroy;
+import okhttp3.ConnectionPool;
+import okhttp3.Dispatcher;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Component("doubaoClient")
+public class DoubaoClient implements LLMClient {
+    private final ArkService service;
+
+    public DoubaoClient(@Value("${thirdparty.doubao.api-key:}") String apiKey,
+                         @Value("${thirdparty.doubao.base-url:https://ark.cn-beijing.volces.com/api/v3}") String baseUrl) {
+        this.service = ArkService.builder()
+                .dispatcher(new Dispatcher())
+                .connectionPool(new ConnectionPool(5, 1, TimeUnit.SECONDS))
+                .baseUrl(baseUrl)
+                .apiKey(apiKey)
+                .build();
+    }
+
+    DoubaoClient(ArkService service) {
+        this.service = service;
+    }
+
+    @Override
+    public String name() {
+        return "doubao";
+    }
+
+    @Override
+    public String chat(List<ChatMessage> messages, double temperature) {
+        List<com.volcengine.ark.runtime.model.completion.chat.ChatMessage> reqMessages = new ArrayList<>();
+        for (ChatMessage m : messages) {
+            reqMessages.add(com.volcengine.ark.runtime.model.completion.chat.ChatMessage.builder()
+                    .role(ChatMessageRole.valueOf(m.getRole().toUpperCase()))
+                    .content(m.getContent())
+                    .build());
+        }
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(LlmModel.DOUBAO_FLASH.getModelName())
+                .messages(reqMessages)
+                .temperature(temperature)
+                .build();
+        ChatCompletionResponse response = service.createChatCompletion(request);
+        return response.getChoices().get(0).getMessage().getContent();
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        service.shutdownExecutor();
+    }
+}

--- a/src/main/java/com/glancy/backend/controller/LlmController.java
+++ b/src/main/java/com/glancy/backend/controller/LlmController.java
@@ -1,0 +1,27 @@
+package com.glancy.backend.controller;
+
+import com.glancy.backend.entity.LlmModel;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Provides meta information about available LLM models.
+ */
+@RestController
+@RequestMapping("/api/llm")
+public class LlmController {
+
+    @GetMapping("/models")
+    public ResponseEntity<List<String>> getModels() {
+        List<String> models = Arrays.stream(LlmModel.values())
+                .map(Enum::name)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(models);
+    }
+}

--- a/src/main/java/com/glancy/backend/entity/LlmModel.java
+++ b/src/main/java/com/glancy/backend/entity/LlmModel.java
@@ -1,0 +1,19 @@
+package com.glancy.backend.entity;
+
+/**
+ * Available large language models.
+ */
+public enum LlmModel {
+    DEEPSEEK("deepseek-chat"),
+    DOUBAO_FLASH("doubao-seed-1-6-flash-250715");
+
+    private final String modelName;
+
+    LlmModel(String modelName) {
+        this.modelName = modelName;
+    }
+
+    public String getModelName() {
+        return modelName;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,6 +50,9 @@ thirdparty:
         base-url: https://api.deepseek.com
         api-key: ''
 
+    doubao:
+        base-url: https://ark.cn-beijing.volces.com/api/v3
+        api-key: ''
 oss:
     endpoint: https://oss-cn-beijing.aliyuncs.com
     bucket: glancy-avatar-bucket

--- a/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
+++ b/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
@@ -1,0 +1,46 @@
+package com.glancy.backend.client;
+
+import com.glancy.backend.llm.model.ChatMessage;
+import com.volcengine.ark.runtime.model.completion.chat.ChatCompletionRequest;
+import com.volcengine.ark.runtime.model.completion.chat.ChatCompletionResponse;
+import com.volcengine.ark.runtime.model.completion.chat.ChatCompletionResponse.Choice;
+import com.volcengine.ark.runtime.model.completion.chat.ChatCompletionResponse.Message;
+import com.volcengine.ark.runtime.service.ArkService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class DoubaoClientTest {
+    private ArkService service;
+    private DoubaoClient client;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(ArkService.class);
+        client = new DoubaoClient(service);
+    }
+
+    @Test
+    void chatReturnsContent() {
+        ChatCompletionResponse resp = new ChatCompletionResponse();
+        Choice choice = new Choice();
+        Message msg = new Message();
+        msg.setContent("hi");
+        choice.setMessage(msg);
+        resp.setChoices(List.of(choice));
+        when(service.createChatCompletion(any(ChatCompletionRequest.class))).thenReturn(resp);
+
+        String result = client.chat(List.of(new ChatMessage("user", "hi")), 0.5);
+
+        ArgumentCaptor<ChatCompletionRequest> cap = ArgumentCaptor.forClass(ChatCompletionRequest.class);
+        verify(service).createChatCompletion(cap.capture());
+        assertEquals("hi", result);
+    }
+}
+

--- a/src/test/java/com/glancy/backend/controller/LlmControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/LlmControllerTest.java
@@ -1,0 +1,30 @@
+package com.glancy.backend.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.context.annotation.Import;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@WebMvcTest(LlmController.class)
+@Import({com.glancy.backend.config.SecurityConfig.class,
+        com.glancy.backend.config.WebConfig.class,
+        com.glancy.backend.config.TokenAuthenticationInterceptor.class,
+        com.glancy.backend.config.auth.AuthenticatedUserArgumentResolver.class})
+class LlmControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void getModels() throws Exception {
+        mockMvc.perform(get("/api/llm/models"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0]").value("DEEPSEEK"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- integrate Doubao LLM client using Ark runtime SDK
- enumerate available LLM models via new `LlmModel` enum
- expose `/api/llm/models` endpoint
- add basic tests for new client and controller
- update curl test script and application config
- load Doubao API key with the same style as DeepSeek

## Testing
- `./mvnw test -q` *(failed: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_688a41f3c0348332b8a8e4f13a3e5234