### PR TITLE
[Feature] support optional model parameter

### DIFF
--- a/CURL_TESTS.md
+++ b/CURL_TESTS.md
@@ -30,4 +30,5 @@ curl -i -H "Content-Type: application/json" \
 
 ```bash
 curl -i "http://localhost:8080/api/words?userId=1&term=hello&language=ENGLISH"
+curl -i "http://localhost:8080/api/words?userId=1&term=hello&language=ENGLISH&model=doubao"
 ```

--- a/scripts/curl-tests.sh
+++ b/scripts/curl-tests.sh
@@ -90,8 +90,11 @@ curl -i -X DELETE "$BASE_URL/api/search-records/user/1/1/favorite"
 section "Delete one search record"
 curl -i -X DELETE "$BASE_URL/api/search-records/user/1/1"
 
-section "Lookup word"
+section "Lookup word (default model)"
 curl -i "$BASE_URL/api/words?userId=1&term=hello&language=ENGLISH"
+
+section "Lookup word (doubao model)"
+curl -i "$BASE_URL/api/words?userId=1&term=hello&language=ENGLISH&model=doubao"
 
 section "Clear search records"
 curl -i -X DELETE "$BASE_URL/api/search-records/user/1"

--- a/src/main/java/com/glancy/backend/controller/WordController.java
+++ b/src/main/java/com/glancy/backend/controller/WordController.java
@@ -37,13 +37,15 @@ public class WordController {
     @GetMapping
     public ResponseEntity<WordResponse> getWord(@AuthenticatedUser Long userId,
                                                 @RequestParam String term,
-                                                @RequestParam Language language) {
-        log.info("Received getWord request from user {} with term '{}' and language {}", userId, term, language);
+                                                @RequestParam Language language,
+                                                @RequestParam(required = false) String model) {
+        log.info("Received getWord request from user {} with term '{}' and language {} using model {}",
+                userId, term, language, model);
         SearchRecordRequest req = new SearchRecordRequest();
         req.setTerm(term);
         req.setLanguage(language);
         searchRecordService.saveRecord(userId, req);
-        WordResponse resp = wordService.findWordForUser(userId, term, language);
+        WordResponse resp = wordService.findWordForUser(userId, term, language, model);
         log.info("Returning word response for term '{}': {}", term, resp);
         return ResponseEntity.ok(resp);
     }

--- a/src/main/java/com/glancy/backend/service/WordService.java
+++ b/src/main/java/com/glancy/backend/service/WordService.java
@@ -45,8 +45,8 @@ public class WordService {
     }
 
     @Transactional
-    public WordResponse findWordForUser(Long userId, String term, Language language) {
-        log.info("Finding word '{}' for user {} in language {}", term, userId, language);
+    public WordResponse findWordForUser(Long userId, String term, Language language, String model) {
+        log.info("Finding word '{}' for user {} in language {} using model {}", term, userId, language, model);
         userPreferenceRepository.findByUserId(userId)
                 .orElseGet(() -> {
                     log.info("No user preference found for user {}, using default", userId);
@@ -61,7 +61,7 @@ public class WordService {
                 })
                 .orElseGet(() -> {
                     log.info("Word '{}' not found locally, searching via LLM", term);
-                    WordResponse resp = wordSearcher.search(term, language, "deepseek");
+                    WordResponse resp = wordSearcher.search(term, language, model);
                     log.info("LLM search result: {}", resp);
                     saveWord(term, resp, language);
                     return resp;

--- a/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -44,7 +44,7 @@ class WordControllerTest {
     void testGetWord() throws Exception {
         WordResponse resp = new WordResponse("1", "hello", List.of("g"), Language.ENGLISH,
                 "ex", "həˈloʊ", List.of(), List.of(), List.of(), List.of(), List.of());
-        when(wordService.findWordForUser(eq(1L), eq("hello"), eq(Language.ENGLISH))).thenReturn(resp);
+        when(wordService.findWordForUser(eq(1L), eq("hello"), eq(Language.ENGLISH), eq(null))).thenReturn(resp);
 
         doNothing().when(userService).validateToken(1L, "tkn");
 
@@ -58,6 +58,29 @@ class WordControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value("1"))
                 .andExpect(jsonPath("$.term").value("hello"));
+    }
+
+    /**
+     * 测试携带模型参数时接口正常工作
+     */
+    @Test
+    void testGetWordWithModel() throws Exception {
+        WordResponse resp = new WordResponse("1", "hello", List.of("g"), Language.ENGLISH,
+                "ex", "həˈloʊ", List.of(), List.of(), List.of(), List.of(), List.of());
+        when(wordService.findWordForUser(eq(1L), eq("hello"), eq(Language.ENGLISH), eq("doubao"))).thenReturn(resp);
+
+        doNothing().when(userService).validateToken(1L, "tkn");
+
+        mockMvc.perform(get("/api/words")
+                        .param("userId", "1")
+                        .header("X-USER-TOKEN", "tkn")
+                        .param("term", "hello")
+                        .param("language", "ENGLISH")
+                        .param("model", "doubao")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("1"));
     }
 
 

--- a/src/test/java/com/glancy/backend/service/WordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/WordServiceTest.java
@@ -50,7 +50,7 @@ class WordServiceTest {
      */
     @Test
     void testFetchAndCacheWord() {
-        WordResponse result = wordService.findWordForUser(1L, "hello", Language.ENGLISH);
+        WordResponse result = wordService.findWordForUser(1L, "hello", Language.ENGLISH, null);
 
         assertNotNull(result.getId());
         assertTrue(wordRepository.findById(Long.parseLong(result.getId())).isPresent());
@@ -67,7 +67,7 @@ class WordServiceTest {
         word.setDefinitions(List.of("store"));
         wordRepository.save(word);
 
-        WordResponse result = wordService.findWordForUser(1L, "cached", Language.ENGLISH);
+        WordResponse result = wordService.findWordForUser(1L, "cached", Language.ENGLISH, null);
 
         assertEquals(String.valueOf(word.getId()), result.getId());
     }
@@ -88,7 +88,7 @@ class WordServiceTest {
      */
     @Test
     void testCacheWordWhenLanguageMissing() {
-        WordResponse result = wordService.findWordForUser(1L, "bye", Language.ENGLISH);
+        WordResponse result = wordService.findWordForUser(1L, "bye", Language.ENGLISH, null);
 
         assertEquals(Language.ENGLISH, result.getLanguage());
         assertTrue(wordRepository.findByTermAndLanguageAndDeletedFalse("bye", Language.ENGLISH).isPresent());


### PR DESCRIPTION
## Summary
- extend `WordController.getWord` with optional `model` parameter
- forward model through `WordService` to `WordSearcher`
- add tests for selecting models
- update curl script and doc examples

## Testing
- `mvn -q test` *(failed: Network is unreachable during dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_e_688a4afab11483328746db95a17ae1af