### PR TITLE
[Fix] handle missing llm client

### DIFF
--- a/src/main/java/com/glancy/backend/llm/service/WordSearcherImpl.java
+++ b/src/main/java/com/glancy/backend/llm/service/WordSearcherImpl.java
@@ -43,6 +43,16 @@ public class WordSearcherImpl implements WordSearcher {
         String prompt = promptManager.loadPrompt(config.getPromptPath());
         String name = clientName != null ? clientName : config.getDefaultClient();
         LLMClient client = clientFactory.get(name);
+        if (client == null) {
+            log.warn("LLM client '{}' not found, falling back to default", name);
+            String fallback = config.getDefaultClient();
+            client = clientFactory.get(fallback);
+            if (client == null) {
+                throw new IllegalStateException(
+                        String.format("LLM client '%s' not available and default '%s' not configured", name, fallback));
+            }
+            name = fallback;
+        }
         List<ChatMessage> messages = new ArrayList<>();
         messages.add(new ChatMessage("system", prompt));
         messages.add(new ChatMessage("user", cleanInput));

--- a/src/test/java/com/glancy/backend/llm/service/WordSearcherImplTest.java
+++ b/src/test/java/com/glancy/backend/llm/service/WordSearcherImplTest.java
@@ -1,0 +1,67 @@
+package com.glancy.backend.llm.service;
+
+import com.glancy.backend.dto.WordResponse;
+import com.glancy.backend.entity.Language;
+import com.glancy.backend.llm.config.LLMConfig;
+import com.glancy.backend.llm.llm.LLMClient;
+import com.glancy.backend.llm.llm.LLMClientFactory;
+import com.glancy.backend.llm.parser.WordResponseParser;
+import com.glancy.backend.llm.prompt.PromptManager;
+import com.glancy.backend.llm.search.SearchContentManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class WordSearcherImplTest {
+    private LLMClientFactory factory;
+    private LLMConfig config;
+    private PromptManager promptManager;
+    private SearchContentManager searchContentManager;
+    private WordResponseParser parser;
+    private LLMClient defaultClient;
+
+    @BeforeEach
+    void setUp() {
+        factory = mock(LLMClientFactory.class);
+        config = new LLMConfig();
+        config.setDefaultClient("deepseek");
+        config.setTemperature(0.5);
+        config.setPromptPath("path");
+        promptManager = mock(PromptManager.class);
+        searchContentManager = mock(SearchContentManager.class);
+        parser = mock(WordResponseParser.class);
+        defaultClient = mock(LLMClient.class);
+    }
+
+    @Test
+    void searchFallsBackToDefaultWhenClientMissing() {
+        when(factory.get("invalid")).thenReturn(null);
+        when(factory.get("deepseek")).thenReturn(defaultClient);
+        when(promptManager.loadPrompt(anyString())).thenReturn("prompt");
+        when(searchContentManager.normalize("hello")).thenReturn("hello");
+        when(defaultClient.chat(anyList(), eq(0.5))).thenReturn("content");
+        WordResponse expected = new WordResponse();
+        when(parser.parse("content", "hello", Language.ENGLISH)).thenReturn(expected);
+
+        WordSearcherImpl searcher = new WordSearcherImpl(factory, config, promptManager, searchContentManager, parser);
+        WordResponse result = searcher.search("hello", Language.ENGLISH, "invalid");
+
+        assertSame(expected, result);
+        verify(factory).get("invalid");
+        verify(factory).get("deepseek");
+        verify(defaultClient).chat(anyList(), eq(0.5));
+    }
+
+    @Test
+    void searchThrowsWhenDefaultMissing() {
+        when(factory.get("invalid")).thenReturn(null);
+        when(factory.get("deepseek")).thenReturn(null);
+        WordSearcherImpl searcher = new WordSearcherImpl(factory, config, promptManager, searchContentManager, parser);
+        assertThrows(IllegalStateException.class, () -> searcher.search("hi", Language.ENGLISH, "invalid"));
+    }
+}


### PR DESCRIPTION
## Summary
- handle missing LLM client in `WordSearcherImpl`
- add unit tests for invalid model values

## Testing
- `./mvnw test -q` *(failed: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688a4fd3ed488332b59642e3a6d521ce