### PR TITLE
[Fix] replace volcengine dependency with HTTP DoubaoClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,11 +102,6 @@
                         <artifactId>aliyun-sdk-oss</artifactId>
                         <version>3.18.2</version>
                 </dependency>
-                <dependency>
-                        <groupId>com.volcengine</groupId>
-                        <artifactId>volcengine-java-sdk-ark-runtime</artifactId>
-                        <version>LATEST</version>
-                </dependency>
         </dependencies>
 
     <build>

--- a/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
+++ b/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
@@ -1,46 +1,41 @@
 package com.glancy.backend.client;
 
 import com.glancy.backend.llm.model.ChatMessage;
-import com.volcengine.ark.runtime.model.completion.chat.ChatCompletionRequest;
-import com.volcengine.ark.runtime.model.completion.chat.ChatCompletionResponse;
-import com.volcengine.ark.runtime.model.completion.chat.ChatCompletionResponse.Choice;
-import com.volcengine.ark.runtime.model.completion.chat.ChatCompletionResponse.Message;
-import com.volcengine.ark.runtime.service.ArkService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 class DoubaoClientTest {
-    private ArkService service;
+    private MockRestServiceServer server;
     private DoubaoClient client;
 
     @BeforeEach
     void setUp() {
-        service = mock(ArkService.class);
-        client = new DoubaoClient(service);
+        RestTemplate restTemplate = new RestTemplate();
+        server = MockRestServiceServer.bindTo(restTemplate).build();
+        client = new DoubaoClient(restTemplate, "http://mock", "key");
     }
 
     @Test
     void chatReturnsContent() {
-        ChatCompletionResponse resp = new ChatCompletionResponse();
-        Choice choice = new Choice();
-        Message msg = new Message();
-        msg.setContent("hi");
-        choice.setMessage(msg);
-        resp.setChoices(List.of(choice));
-        when(service.createChatCompletion(any(ChatCompletionRequest.class))).thenReturn(resp);
+        String json = "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"hi\"}}]}";
+        server.expect(requestTo("http://mock/v1/chat/completions"))
+                .andExpect(method(POST))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer key"))
+                .andRespond(withSuccess(json, MediaType.APPLICATION_JSON));
 
         String result = client.chat(List.of(new ChatMessage("user", "hi")), 0.5);
-
-        ArgumentCaptor<ChatCompletionRequest> cap = ArgumentCaptor.forClass(ChatCompletionRequest.class);
-        verify(service).createChatCompletion(cap.capture());
         assertEquals("hi", result);
+        server.verify();
     }
 }
-


### PR DESCRIPTION
## Summary
- remove `volcengine-java-sdk-ark-runtime` dependency
- rewrite `DoubaoClient` to call the API via `RestTemplate`
- update tests for the new implementation

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688a4e835ecc83329940a60f30ded0c8