### PR TITLE
[Feature] Expose LLM client names

### DIFF
--- a/src/main/java/com/glancy/backend/controller/LlmController.java
+++ b/src/main/java/com/glancy/backend/controller/LlmController.java
@@ -1,14 +1,12 @@
 package com.glancy.backend.controller;
 
-import com.glancy.backend.entity.LlmModel;
+import com.glancy.backend.llm.llm.LLMClientFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Provides meta information about available LLM models.
@@ -16,12 +14,15 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping("/api/llm")
 public class LlmController {
+    private final LLMClientFactory clientFactory;
+
+    public LlmController(LLMClientFactory clientFactory) {
+        this.clientFactory = clientFactory;
+    }
 
     @GetMapping("/models")
     public ResponseEntity<List<String>> getModels() {
-        List<String> models = Arrays.stream(LlmModel.values())
-                .map(Enum::name)
-                .collect(Collectors.toList());
+        List<String> models = clientFactory.getClientNames();
         return ResponseEntity.ok(models);
     }
 }

--- a/src/main/java/com/glancy/backend/llm/llm/LLMClientFactory.java
+++ b/src/main/java/com/glancy/backend/llm/llm/LLMClientFactory.java
@@ -1,5 +1,7 @@
 package com.glancy.backend.llm.llm;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,5 +21,14 @@ public class LLMClientFactory {
 
     public LLMClient get(String name) {
         return clientMap.get(name);
+    }
+
+    /**
+     * Returns the names of all registered LLM clients sorted alphabetically.
+     */
+    public List<String> getClientNames() {
+        List<String> names = new ArrayList<>(clientMap.keySet());
+        Collections.sort(names);
+        return names;
     }
 }

--- a/src/test/java/com/glancy/backend/controller/LlmControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/LlmControllerTest.java
@@ -5,6 +5,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.glancy.backend.llm.llm.LLMClientFactory;
+import java.util.List;
+import static org.mockito.BDDMockito.given;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -19,12 +24,17 @@ class LlmControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @MockitoBean
+    private LLMClientFactory clientFactory;
+
     @Test
     void getModels() throws Exception {
+        given(clientFactory.getClientNames()).willReturn(List.of("deepseek", "doubao"));
         mockMvc.perform(get("/api/llm/models"))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0]").value("DEEPSEEK"));
+                .andExpect(jsonPath("$[0]").value("deepseek"))
+                .andExpect(jsonPath("$[1]").value("doubao"));
     }
 }
 


### PR DESCRIPTION
## Summary
- show available LLM client names from factory
- inject `LLMClientFactory` into `LlmController`
- adjust test to expect client names

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688a4fca1104833288e7ecfcba1deffb