### PR TITLE
[Fix] Bump Spring Boot to 3.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.3</version>
+                <version>3.5.4</version>
 	</parent>
 	<groupId>com.glancy</groupId>
 	<artifactId>glancy-backend</artifactId>


### PR DESCRIPTION
## Summary
- update `spring-boot-starter-parent` to version 3.5.4 in `pom.xml`

## Testing
- `./mvnw test -q` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688a594a58a08332a1d36b1db84aeb9e