### PR TITLE
[Fix] provide available LLM models

### DIFF
--- a/src/main/java/com/glancy/backend/controller/LlmController.java
+++ b/src/main/java/com/glancy/backend/controller/LlmController.java
@@ -1,6 +1,7 @@
 package com.glancy.backend.controller;
 
 import com.glancy.backend.llm.llm.LLMClientFactory;
+import com.glancy.backend.service.LlmModelService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,14 +16,16 @@ import java.util.List;
 @RequestMapping("/api/llm")
 public class LlmController {
     private final LLMClientFactory clientFactory;
+    private final LlmModelService modelService;
 
-    public LlmController(LLMClientFactory clientFactory) {
+    public LlmController(LLMClientFactory clientFactory, LlmModelService modelService) {
         this.clientFactory = clientFactory;
+        this.modelService = modelService;
     }
 
     @GetMapping("/models")
     public ResponseEntity<List<String>> getModels() {
-        List<String> models = clientFactory.getClientNames();
+        List<String> models = modelService.getModelNames();
         return ResponseEntity.ok(models);
     }
 }

--- a/src/main/java/com/glancy/backend/service/LlmModelService.java
+++ b/src/main/java/com/glancy/backend/service/LlmModelService.java
@@ -1,0 +1,24 @@
+package com.glancy.backend.service;
+
+import com.glancy.backend.entity.LlmModel;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Provides available LLM model names in a sorted list.
+ */
+@Service
+public class LlmModelService {
+
+    /**
+     * Returns all supported model names sorted alphabetically.
+     */
+    public List<String> getModelNames() {
+        return Arrays.stream(LlmModel.values())
+                .map(Enum::name)
+                .sorted()
+                .toList();
+    }
+}

--- a/src/test/java/com/glancy/backend/controller/LlmControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/LlmControllerTest.java
@@ -7,7 +7,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-import com.glancy.backend.llm.llm.LLMClientFactory;
+import com.glancy.backend.service.LlmModelService;
 import java.util.List;
 import static org.mockito.BDDMockito.given;
 
@@ -25,16 +25,16 @@ class LlmControllerTest {
     private MockMvc mockMvc;
 
     @MockitoBean
-    private LLMClientFactory clientFactory;
+    private LlmModelService modelService;
 
     @Test
     void getModels() throws Exception {
-        given(clientFactory.getClientNames()).willReturn(List.of("deepseek", "doubao"));
+        given(modelService.getModelNames()).willReturn(List.of("DEEPSEEK", "DOUBAO_FLASH"));
         mockMvc.perform(get("/api/llm/models"))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0]").value("deepseek"))
-                .andExpect(jsonPath("$[1]").value("doubao"));
+                .andExpect(jsonPath("$[0]").value("DEEPSEEK"))
+                .andExpect(jsonPath("$[1]").value("DOUBAO_FLASH"));
     }
 }
 


### PR DESCRIPTION
## Summary
- expose a service to list available LLM models
- use the new service in `LlmController`
- adjust the test to verify model names

## Testing
- `mvn -q test` *(failed: could not resolve parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_688a594ac4588332b1b4513ae0f20c91