### PR TITLE
[Fix] Remove unused imports and annotations

### DIFF
--- a/src/main/java/com/glancy/backend/llm/llm/LLMClientFactory.java
+++ b/src/main/java/com/glancy/backend/llm/llm/LLMClientFactory.java
@@ -5,14 +5,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class LLMClientFactory {
     private final Map<String, LLMClient> clientMap = new HashMap<>();
 
-    @Autowired
     public LLMClientFactory(List<LLMClient> clients) {
         for (LLMClient client : clients) {
             clientMap.put(client.name(), client);

--- a/src/main/java/com/glancy/backend/service/UserService.java
+++ b/src/main/java/com/glancy/backend/service/UserService.java
@@ -20,8 +20,6 @@ import com.glancy.backend.entity.ThirdPartyAccount;
 import com.glancy.backend.repository.UserRepository;
 import com.glancy.backend.repository.LoginDeviceRepository;
 import com.glancy.backend.repository.ThirdPartyAccountRepository;
-import com.glancy.backend.service.UserProfileService;
-import com.glancy.backend.service.AvatarStorage;
 import com.glancy.backend.exception.ResourceNotFoundException;
 import com.glancy.backend.exception.DuplicateResourceException;
 import com.glancy.backend.exception.InvalidRequestException;

--- a/src/test/java/com/glancy/backend/llm/service/WordSearcherImplTest.java
+++ b/src/test/java/com/glancy/backend/llm/service/WordSearcherImplTest.java
@@ -11,7 +11,6 @@ import com.glancy.backend.llm.search.SearchContentManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;

--- a/src/test/java/com/glancy/backend/service/OssAvatarStorageTest.java
+++ b/src/test/java/com/glancy/backend/service/OssAvatarStorageTest.java
@@ -5,7 +5,6 @@ import org.springframework.mock.web.MockMultipartFile;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
-import static org.mockito.ArgumentMatchers.*;
 
 import com.aliyun.oss.OSS;
 import com.aliyun.oss.OSSException;
@@ -13,7 +12,6 @@ import com.aliyun.oss.model.CannedAccessControlList;
 import com.aliyun.oss.model.GeneratePresignedUrlRequest;
 import com.glancy.backend.config.OssProperties;
 import java.util.Date;
-import java.net.URL;
 
 /**
  * Simple tests for OssAvatarStorage.

--- a/src/test/java/com/glancy/backend/service/WordServiceTest.java
+++ b/src/test/java/com/glancy/backend/service/WordServiceTest.java
@@ -5,8 +5,6 @@ import com.glancy.backend.entity.Language;
 import com.glancy.backend.entity.Word;
 import com.glancy.backend.repository.WordRepository;
 import com.glancy.backend.repository.UserPreferenceRepository;
-import com.glancy.backend.entity.UserPreference;
-import com.glancy.backend.entity.DictionaryModel;
 import io.github.cdimascio.dotenv.Dotenv;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
## Summary
- clean up unused imports in `UserService` and tests
- drop `@Autowired` from `LLMClientFactory`

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688a5a3ace348332875fcd30d4b64037