### PR TITLE
[Feature] Simplify deploy workflow via ssh-action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,17 +14,13 @@ jobs:
         uses: actions/checkout@v3
 
 
-      - name: Setup SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H ${{ secrets.REMOTE_HOST }} >> ~/.ssh/known_hosts
-          ssh-keyscan -H github.com >> ~/.ssh/known_hosts
-
-      - name: 部署到远程服务器
-        run: |
-          ssh ${{ secrets.REMOTE_USER }}@${{ secrets.REMOTE_HOST }} << 'EOF2'
+      - name: Deploy to remote server
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.REMOTE_HOST }}
+          username: ${{ secrets.REMOTE_USER }}
+          key: ${{ secrets.DEPLOY_KEY }}
+          script: |
             set -e
             cd /home/ecs-user/glancy-backend
 
@@ -68,4 +64,3 @@ jobs:
             nohup java -jar target/glancy-backend.jar > backend.log 2>&1 &
 
             echo "✅ 部署完成"
-          EOF2


### PR DESCRIPTION
## Summary
- use appleboy/ssh-action in deploy workflow for managing SSH connection

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688a6134c44483328340d228c22c0b4b