### PR TITLE
[Fix] Remove redundant port from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,6 @@ jobs:
                   host: ${{ secrets.REMOTE_HOST }}
                   username: ${{ secrets.REMOTE_USER }}
                   key: ${{ secrets.DEPLOY_KEY }}
-                  port: ${{ secrets.REMOTE_PORT }}
                   timeout: 2m
                   source: target/glancy-backend.jar
                   target: /home/ecs-user/glancy-backend/target/


### PR DESCRIPTION
## Summary
- remove unused `REMOTE_PORT` from deploy workflow

## Testing
- `./mvnw test -q` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688a68e01fa08332a6262b350d1b1b43