### PR TITLE
[Fix] handle missing systemd service

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,5 +41,9 @@ jobs:
                   username: ${{ secrets.REMOTE_USER }}
                   key: ${{ secrets.DEPLOY_KEY }}
                   script: |
-                      sudo systemctl restart glancy-backend.service
+                      if sudo systemctl list-units --type=service --all | grep -q 'glancy-backend.service'; then
+                          sudo systemctl restart glancy-backend.service
+                      else
+                          echo 'glancy-backend.service not found on remote host'
+                      fi
 

--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -14,5 +14,9 @@ jobs:
                   username: ${{ secrets.SERVER_USER }}
                   key: ${{ secrets.SERVER_KEY }}
                   script: |
-                      sudo systemctl restart glancy-backend.service
+                      if sudo systemctl list-units --type=service --all | grep -q 'glancy-backend.service'; then
+                          sudo systemctl restart glancy-backend.service
+                      else
+                          echo 'glancy-backend.service not found on remote host'
+                      fi
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,31 @@ Or build a jar:
 java -jar target/glancy-backend.jar
 ```
 
+## Deploying as a Systemd Service
+
+The project can run under `systemd` for easier management. Example unit file:
+
+```ini
+[Unit]
+Description=Glancy Backend Service
+After=network.target
+
+[Service]
+User=ecs-user
+WorkingDirectory=/home/ecs-user/glancy-backend
+ExecStart=/usr/bin/java -jar /home/ecs-user/glancy-backend/target/glancy-backend.jar
+SuccessExitStatus=143
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Place this file at `/etc/systemd/system/glancy-backend.service` on the server,
+run `sudo systemctl daemon-reload` and `sudo systemctl enable --now glancy-backend.service`.
+The deployment workflow expects this service name when restarting the application.
+
 ## Running Tests
 
 ```bash


### PR DESCRIPTION
## Summary
- avoid failures when glancy-backend.service is missing
- show how to install the service with systemd

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688a6ee857248332911df33213bb0db7