### PR TITLE
[Fix] fetch llm clients dynamically

### DIFF
--- a/src/main/java/com/glancy/backend/service/LlmModelService.java
+++ b/src/main/java/com/glancy/backend/service/LlmModelService.java
@@ -1,10 +1,9 @@
 package com.glancy.backend.service;
 
-import com.glancy.backend.entity.LlmModel;
+import com.glancy.backend.llm.llm.LLMClientFactory;
 import org.springframework.stereotype.Service;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -13,16 +12,18 @@ import java.util.List;
 @Slf4j
 @Service
 public class LlmModelService {
+    private final LLMClientFactory clientFactory;
+
+    public LlmModelService(LLMClientFactory clientFactory) {
+        this.clientFactory = clientFactory;
+    }
 
     /**
-     * Returns all supported model names sorted alphabetically.
+     * Returns all registered LLM client names sorted alphabetically.
      */
     public List<String> getModelNames() {
-        log.debug("Fetching supported LLM model names");
-        List<String> names = Arrays.stream(LlmModel.values())
-                .map(Enum::name)
-                .sorted()
-                .toList();
+        log.debug("Fetching registered LLM client names");
+        List<String> names = clientFactory.getClientNames();
         log.debug("Available models: {}", names);
         return names;
     }

--- a/src/test/java/com/glancy/backend/controller/LlmControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/LlmControllerTest.java
@@ -29,12 +29,12 @@ class LlmControllerTest {
 
     @Test
     void getModels() throws Exception {
-        given(modelService.getModelNames()).willReturn(List.of("DEEPSEEK", "DOUBAO_FLASH"));
+        given(modelService.getModelNames()).willReturn(List.of("deepseek", "doubao"));
         mockMvc.perform(get("/api/llm/models"))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0]").value("DEEPSEEK"))
-                .andExpect(jsonPath("$[1]").value("DOUBAO_FLASH"));
+                .andExpect(jsonPath("$[0]").value("deepseek"))
+                .andExpect(jsonPath("$[1]").value("doubao"));
     }
 }
 


### PR DESCRIPTION
## Summary
- adjust `LlmModelService` to use `LLMClientFactory` so `/api/llm/models` returns active client names
- update controller test expectations

## Testing
- `./mvnw -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688a719be45c8332936d188cc19e9664