### PR TITLE
[Fix] handle duplicate env keys gracefully

### DIFF
--- a/src/main/java/com/glancy/backend/GlancyBackendApplication.java
+++ b/src/main/java/com/glancy/backend/GlancyBackendApplication.java
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.client.RestTemplate;
 import lombok.extern.slf4j.Slf4j;
+import com.glancy.backend.util.EnvLoader;
 
 /**
  * Application entry point for the Glancy dictionary backend.
@@ -19,28 +20,7 @@ public class GlancyBackendApplication {
      * from a .env file for convenience during development.
      */
     public static void main(String[] args) {
-        io.github.cdimascio.dotenv.Dotenv dotenv =
-                io.github.cdimascio.dotenv.Dotenv.configure().ignoreIfMissing().load();
-        String dbPassword = dotenv.get("DB_PASSWORD");
-        if (dbPassword != null) {
-            System.setProperty("DB_PASSWORD", dbPassword);
-        }
-        String deepseekKey = dotenv.get("thirdparty.deepseek.api-key");
-        if (deepseekKey != null) {
-            System.setProperty("thirdparty.deepseek.api-key", deepseekKey);
-        }
-        String doubaoKey = dotenv.get("thirdparty.doubao.api-key");
-        if (doubaoKey != null) {
-            System.setProperty("thirdparty.doubao.api-key", doubaoKey);
-        }
-        String ossKey = dotenv.get("OSS_ACCESS_KEY_ID");
-        if (ossKey != null) {
-            System.setProperty("OSS_ACCESS_KEY_ID", ossKey);
-        }
-        String ossSecret = dotenv.get("OSS_ACCESS_KEY_SECRET");
-        if (ossSecret != null) {
-            System.setProperty("OSS_ACCESS_KEY_SECRET", ossSecret);
-        }
+        EnvLoader.load(java.nio.file.Paths.get(".env"));
         SpringApplication.run(GlancyBackendApplication.class, args);
     }
 

--- a/src/main/java/com/glancy/backend/util/EnvLoader.java
+++ b/src/main/java/com/glancy/backend/util/EnvLoader.java
@@ -1,0 +1,40 @@
+package com.glancy.backend.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+/**
+ * Utility to load key-value pairs from a .env file without failing when keys
+ * appear multiple times. Later entries override previous ones.
+ */
+public final class EnvLoader {
+    private EnvLoader() {}
+
+    /**
+     * Loads environment variables from the given path if it exists.
+     * Duplicate keys are resolved by keeping the last value.
+     *
+     * @param file path to the .env file
+     */
+    public static void load(Path file) {
+        if (!Files.exists(file)) {
+            return;
+        }
+        try (Stream<String> lines = Files.lines(file)) {
+            lines.map(String::trim)
+                 .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                 .forEach(line -> {
+                     int idx = line.indexOf('=');
+                     if (idx > 0) {
+                         String key = line.substring(0, idx).trim();
+                         String value = line.substring(idx + 1).trim();
+                         System.setProperty(key, value);
+                     }
+                 });
+        } catch (IOException ignored) {
+            // ignore malformed lines and loading errors for developer convenience
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add EnvLoader utility to load .env files without failing on duplicate keys
- simplify `GlancyBackendApplication` to use `EnvLoader` for environment setup

## Testing
- `./mvnw test` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_688a71bf7c1483328c07548ddae8dabf