### PR TITLE
[Fix] Ensure systemd service installed during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,19 @@ jobs:
                   strip_components: 1
                   debug: true
 
+            - name: Upload service unit
+              uses: appleboy/scp-action@v1.0.0
+              with:
+                  host: ${{ secrets.REMOTE_HOST }}
+                  username: ${{ secrets.REMOTE_USER }}
+                  key: ${{ secrets.DEPLOY_KEY }}
+                  timeout: 2m
+                  source: scripts/glancy-backend.service
+                  target: /home/ecs-user/glancy-backend/
+                  overwrite: true
+                  strip_components: 1
+                  debug: true
+
             - name: Restart service
               uses: appleboy/ssh-action@v1.0.0
               with:
@@ -41,9 +54,11 @@ jobs:
                   username: ${{ secrets.REMOTE_USER }}
                   key: ${{ secrets.DEPLOY_KEY }}
                   script: |
+                      sudo cp /home/ecs-user/glancy-backend/glancy-backend.service /etc/systemd/system/glancy-backend.service
+                      sudo systemctl daemon-reload
                       if sudo systemctl list-units --type=service --all | grep -q 'glancy-backend.service'; then
                           sudo systemctl restart glancy-backend.service
                       else
-                          echo 'glancy-backend.service not found on remote host'
+                          sudo systemctl enable --now glancy-backend.service
                       fi
 

--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -14,9 +14,11 @@ jobs:
                   username: ${{ secrets.SERVER_USER }}
                   key: ${{ secrets.SERVER_KEY }}
                   script: |
+                      sudo cp /home/ecs-user/glancy-backend/glancy-backend.service /etc/systemd/system/glancy-backend.service
+                      sudo systemctl daemon-reload
                       if sudo systemctl list-units --type=service --all | grep -q 'glancy-backend.service'; then
                           sudo systemctl restart glancy-backend.service
                       else
-                          echo 'glancy-backend.service not found on remote host'
+                          sudo systemctl enable --now glancy-backend.service
                       fi
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ java -jar target/glancy-backend.jar
 
 ## Deploying as a Systemd Service
 
-The project can run under `systemd` for easier management. Example unit file:
+The project can run under `systemd` for easier management. An example unit file
+is provided at `scripts/glancy-backend.service`:
 
 ```ini
 [Unit]

--- a/scripts/glancy-backend.service
+++ b/scripts/glancy-backend.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Glancy Backend Service
+After=network.target
+
+[Service]
+User=ecs-user
+WorkingDirectory=/home/ecs-user/glancy-backend
+ExecStart=/usr/bin/java -jar /home/ecs-user/glancy-backend/target/glancy-backend.jar
+SuccessExitStatus=143
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- provide a systemd unit file in `scripts/`
- deploy workflow uploads the unit and installs it before restarting
- restart workflow now also installs the unit
- mention the service file location in README

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688afb5d54088332b5ff436d1d352642