### PR TITLE
[Fix] Improve systemd setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,13 @@ After=network.target
 [Service]
 User=ecs-user
 WorkingDirectory=/home/ecs-user/glancy-backend
+EnvironmentFile=/home/ecs-user/glancy-backend/.env
 ExecStart=/usr/bin/java -jar /home/ecs-user/glancy-backend/target/glancy-backend.jar
 SuccessExitStatus=143
 Restart=always
 RestartSec=10
+StandardOutput=file:/home/ecs-user/glancy-backend/backend.log
+StandardError=file:/home/ecs-user/glancy-backend/backend.log
 
 [Install]
 WantedBy=multi-user.target
@@ -72,6 +75,9 @@ WantedBy=multi-user.target
 Place this file at `/etc/systemd/system/glancy-backend.service` on the server,
 run `sudo systemctl daemon-reload` and `sudo systemctl enable --now glancy-backend.service`.
 The deployment workflow expects this service name when restarting the application.
+Create an `.env` file beside the service with `DB_PASSWORD` and any API keys.
+Logs will be written to `backend.log` under the working directory and can also be viewed using
+`journalctl -u glancy-backend.service`.
 
 ## Running Tests
 

--- a/scripts/glancy-backend.service
+++ b/scripts/glancy-backend.service
@@ -5,10 +5,13 @@ After=network.target
 [Service]
 User=ecs-user
 WorkingDirectory=/home/ecs-user/glancy-backend
+EnvironmentFile=/home/ecs-user/glancy-backend/.env
 ExecStart=/usr/bin/java -jar /home/ecs-user/glancy-backend/target/glancy-backend.jar
 SuccessExitStatus=143
 Restart=always
 RestartSec=10
+StandardOutput=file:/home/ecs-user/glancy-backend/backend.log
+StandardError=file:/home/ecs-user/glancy-backend/backend.log
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- document using an environment file and log file for the service
- update `glancy-backend.service` with EnvironmentFile and logging directives

## Testing
- `./mvnw test -q` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688afe479ef48332884b7074ddb61c3f