### PR TITLE
[Fix] Handle unauthorized errors from LLM clients

### DIFF
--- a/src/test/java/com/glancy/backend/client/DeepSeekClientTest.java
+++ b/src/test/java/com/glancy/backend/client/DeepSeekClientTest.java
@@ -15,6 +15,8 @@ import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import org.springframework.http.HttpStatus;
 
 class DeepSeekClientTest {
     private MockRestServiceServer server;
@@ -96,6 +98,17 @@ class DeepSeekClientTest {
 
         byte[] resp = client.fetchAudio("hello", Language.ENGLISH);
         assertArrayEquals(audio, resp);
+        server.verify();
+    }
+
+    @Test
+    void chatUnauthorizedThrowsException() {
+        server.expect(requestTo("http://mock/v1/chat/completions"))
+                .andExpect(method(POST))
+                .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
+
+        assertThrows(com.glancy.backend.exception.UnauthorizedException.class,
+                () -> client.chat(List.of(new com.glancy.backend.llm.model.ChatMessage("user", "hi")), 0.5));
         server.verify();
     }
 

--- a/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
+++ b/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
@@ -11,9 +11,12 @@ import org.springframework.web.client.RestTemplate;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import org.springframework.http.HttpStatus;
 
 class DoubaoClientTest {
     private MockRestServiceServer server;
@@ -36,6 +39,17 @@ class DoubaoClientTest {
 
         String result = client.chat(List.of(new ChatMessage("user", "hi")), 0.5);
         assertEquals("hi", result);
+        server.verify();
+    }
+
+    @Test
+    void chatUnauthorizedThrowsException() {
+        server.expect(requestTo("http://mock/v1/chat/completions"))
+                .andExpect(method(POST))
+                .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
+
+        assertThrows(com.glancy.backend.exception.UnauthorizedException.class,
+                () -> client.chat(List.of(new ChatMessage("user", "hi")), 0.5));
         server.verify();
     }
 }


### PR DESCRIPTION
## Summary
- add unauthorized handling in `DoubaoClient`
- add unauthorized handling in `DeepSeekClient`
- test unauthorized responses for both LLM clients

## Testing
- `./mvnw test -q` *(failed: network unreachable during Maven wrapper download)*

------
https://chatgpt.com/codex/tasks/task_e_688b06cf8134833286ed9e7c86c53d0f