### PR TITLE
[Fix] add missing import in DeepSeekClientTest

### DIFF
--- a/src/test/java/com/glancy/backend/client/DeepSeekClientTest.java
+++ b/src/test/java/com/glancy/backend/client/DeepSeekClientTest.java
@@ -10,6 +10,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;


### PR DESCRIPTION
## Summary
- add `java.util.List` import to `DeepSeekClientTest` to resolve failing compilation

## Testing
- `mvn test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688b0b3855548332bd1c4666a8ee5607