### PR TITLE
[Feature] Add API key logging for third-party clients

### DIFF
--- a/src/main/java/com/glancy/backend/client/DeepSeekClient.java
+++ b/src/main/java/com/glancy/backend/client/DeepSeekClient.java
@@ -43,6 +43,11 @@ public class DeepSeekClient implements DictionaryClient, LLMClient {
         this.baseUrl = baseUrl;
         this.apiKey = apiKey;
         this.parser = parser;
+        if (apiKey == null || apiKey.isBlank()) {
+            log.warn("DeepSeek API key is empty");
+        } else {
+            log.info("DeepSeek API key loaded: {}", maskKey(apiKey));
+        }
         this.enToZhPrompt = loadPrompt("prompts/english_to_chinese.txt");
         this.zhToEnPrompt = loadPrompt("prompts/chinese_to_english.txt");
     }
@@ -145,6 +150,14 @@ public class DeepSeekClient implements DictionaryClient, LLMClient {
                 byte[].class
         );
         return response.getBody();
+    }
+
+    private String maskKey(String key) {
+        if (key.length() <= 8) {
+            return "****";
+        }
+        int end = key.length() - 4;
+        return key.substring(0, 4) + "****" + key.substring(end);
     }
 
 }

--- a/src/main/java/com/glancy/backend/client/DoubaoClient.java
+++ b/src/main/java/com/glancy/backend/client/DoubaoClient.java
@@ -33,6 +33,11 @@ public class DoubaoClient implements LLMClient {
         this.restTemplate = restTemplate;
         this.baseUrl = baseUrl;
         this.apiKey = apiKey;
+        if (apiKey == null || apiKey.isBlank()) {
+            log.warn("Doubao API key is empty");
+        } else {
+            log.info("Doubao API key loaded: {}", maskKey(apiKey));
+        }
     }
 
     @Override
@@ -88,5 +93,13 @@ public class DoubaoClient implements LLMClient {
             log.warn("Failed to parse Doubao response", e);
             return "";
         }
+    }
+
+    private String maskKey(String key) {
+        if (key.length() <= 8) {
+            return "****";
+        }
+        int end = key.length() - 4;
+        return key.substring(0, 4) + "****" + key.substring(end);
     }
 }


### PR DESCRIPTION
## Summary
- log DeepSeek and Doubao API keys on initialization
- mask key value when printed for security

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688b130bdbb083328de93b78297cb74f