### PR TITLE
[Fix] rotate logs on restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ ExecStart=/usr/bin/java -jar /home/ecs-user/glancy-backend/target/glancy-backend
 SuccessExitStatus=143
 Restart=always
 RestartSec=10
-StandardOutput=file:/home/ecs-user/glancy-backend/backend.log
-StandardError=file:/home/ecs-user/glancy-backend/backend.log
+ExecStartPre=/usr/bin/truncate -s 0 /home/ecs-user/glancy-backend/backend.log
+StandardOutput=append:/home/ecs-user/glancy-backend/backend.log
+StandardError=append:/home/ecs-user/glancy-backend/backend.log
 
 [Install]
 WantedBy=multi-user.target
@@ -76,8 +77,8 @@ Place this file at `/etc/systemd/system/glancy-backend.service` on the server,
 run `sudo systemctl daemon-reload` and `sudo systemctl enable --now glancy-backend.service`.
 The deployment workflow expects this service name when restarting the application.
 Create an `.env` file beside the service with `DB_PASSWORD` and any API keys.
-Logs will be written to `backend.log` under the working directory and can also be viewed using
-`journalctl -u glancy-backend.service`.
+Logs will be written to `backend.log` under the working directory. The file is truncated at each service start so old output does not linger. Logback also rotates the file daily and keeps 30 days by default.
+You can also view recent logs with `journalctl -u glancy-backend.service`.
 
 ## Running Tests
 

--- a/scripts/glancy-backend.service
+++ b/scripts/glancy-backend.service
@@ -10,8 +10,9 @@ ExecStart=/usr/bin/java -jar /home/ecs-user/glancy-backend/target/glancy-backend
 SuccessExitStatus=143
 Restart=always
 RestartSec=10
-StandardOutput=file:/home/ecs-user/glancy-backend/backend.log
-StandardError=file:/home/ecs-user/glancy-backend/backend.log
+ExecStartPre=/usr/bin/truncate -s 0 /home/ecs-user/glancy-backend/backend.log
+StandardOutput=append:/home/ecs-user/glancy-backend/backend.log
+StandardError=append:/home/ecs-user/glancy-backend/backend.log
 
 [Install]
 WantedBy=multi-user.target

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true">
+    <property name="LOG_PATH" value="logs"/>
+    <property name="LOG_FILE" value="${LOG_PATH}/glancy.log"/>
+    <property name="ARCHIVE_PATTERN" value="${LOG_PATH}/glancy-%d{yyyy-MM-dd}.%i.log"/>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="RollingFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_FILE}</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${ARCHIVE_PATTERN}</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+        <appender-ref ref="RollingFile"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- clear backend.log at service start and append output
- document log rotation and update service example
- add logback file appender for daily rotation

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688b9c94d2588332bb6bc4a50c243a6b