### PR TITLE
[Fix] Accept login token via parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Bilingual prompt instructions are available in `docs/PROMPT_BILINGUAL.md`.
 - `DELETE /api/users/{id}` – logically delete a user
 - `GET /api/users/{id}` – fetch user details
 - `POST /api/users/login` – user login (send `account` and `password`)
-- 登录成功后将返回 `token`，后续需要在 `X-USER-TOKEN` 请求头中携带此值
+- 登录成功后将返回 `token`，后续请求需在 `X-USER-TOKEN` 请求头或 `token` 参数中携带该值
 - `POST /api/users/{id}/logout` – invalidate the login token
 - `POST /api/users/{id}/third-party-accounts` – bind a third‑party account (returns the bound account)
 - `GET /api/users/count` – total number of active users
@@ -129,7 +129,7 @@ Bilingual prompt instructions are available in `docs/PROMPT_BILINGUAL.md`.
 - `DELETE /api/search-records/user/{userId}/{recordId}` – delete a specific search record of the user
 - `DELETE /api/search-records/user/{userId}` – clear all search records of the user
 - `DELETE /api/search-records/user/{userId}/{recordId}/favorite` – unfavorite a search record
-  以上接口均需在 `X-USER-TOKEN` 请求头中提供登录令牌
+  以上接口均需在 `X-USER-TOKEN` 请求头或 `token` 参数中提供登录令牌
 
 
 

--- a/src/main/java/com/glancy/backend/config/auth/TokenResolver.java
+++ b/src/main/java/com/glancy/backend/config/auth/TokenResolver.java
@@ -1,0 +1,28 @@
+package com.glancy.backend.config.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Utility for extracting the user authentication token from a request.
+ */
+public final class TokenResolver {
+    public static final String HEADER_NAME = "X-USER-TOKEN";
+    public static final String PARAM_NAME = "token";
+
+    private TokenResolver() {}
+
+    /**
+     * Resolve the token from either the {@code X-USER-TOKEN} header or the
+     * {@code token} query parameter.
+     *
+     * @param request the current HTTP request
+     * @return the token value or {@code null} if not found
+     */
+    public static String resolveToken(HttpServletRequest request) {
+        String token = request.getHeader(HEADER_NAME);
+        if (token == null || token.isEmpty()) {
+            token = request.getParameter(PARAM_NAME);
+        }
+        return (token == null || token.isEmpty()) ? null : token;
+    }
+}

--- a/src/main/java/com/glancy/backend/config/auth/UserIdResolver.java
+++ b/src/main/java/com/glancy/backend/config/auth/UserIdResolver.java
@@ -1,0 +1,43 @@
+package com.glancy.backend.config.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility for extracting the userId from path variables or query parameters.
+ */
+public final class UserIdResolver {
+    private UserIdResolver() {}
+
+    /**
+     * Resolve the userId from URI template variables or the {@code userId}
+     * query parameter.
+     *
+     * @param request current HTTP request
+     * @return userId value or {@code null} if not found
+     */
+    public static String resolveUserId(HttpServletRequest request) {
+        Map<String, String> pathVariables = null;
+        Object attr = request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        if (attr instanceof Map<?, ?> map) {
+            pathVariables = new HashMap<>();
+            for (var entry : map.entrySet()) {
+                pathVariables.put(entry.getKey().toString(), entry.getValue().toString());
+            }
+        }
+        String userIdStr = null;
+        if (pathVariables != null) {
+            userIdStr = pathVariables.get("userId");
+            if (userIdStr == null) {
+                userIdStr = pathVariables.get("id");
+            }
+        }
+        if (userIdStr == null) {
+            userIdStr = request.getParameter("userId");
+        }
+        return userIdStr;
+    }
+}

--- a/src/test/java/com/glancy/backend/config/TokenAuthenticationInterceptorTest.java
+++ b/src/test/java/com/glancy/backend/config/TokenAuthenticationInterceptorTest.java
@@ -50,4 +50,16 @@ class TokenAuthenticationInterceptorTest {
                 .content("{\"term\":\"hello\",\"language\":\"ENGLISH\"}"))
                 .andExpect(status().isUnauthorized());
     }
+
+    /**
+     * Test that token provided via query parameter is accepted.
+     */
+    @Test
+    void tokenQueryParamAccepted() throws Exception {
+        mockMvc.perform(post("/api/search-records/user/1")
+                .param("token", "tkn")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"term\":\"hello\",\"language\":\"ENGLISH\"}"))
+                .andExpect(status().isCreated());
+    }
 }

--- a/src/test/java/com/glancy/backend/controller/WordControllerTest.java
+++ b/src/test/java/com/glancy/backend/controller/WordControllerTest.java
@@ -131,4 +131,22 @@ class WordControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("Invalid value for parameter: language"));
     }
-}
+
+    /**
+     * Test access with token query parameter.
+     */
+    @Test
+    void testGetWordTokenQueryParam() throws Exception {
+        WordResponse resp = new WordResponse("1", "hi", List.of("g"), Language.ENGLISH,
+                "ex", "h\u0259\u02c8lo\u028a", List.of(), List.of(), List.of(), List.of(), List.of());
+        when(wordService.findWordForUser(eq(1L), eq("hi"), eq(Language.ENGLISH), eq(null))).thenReturn(resp);
+
+        mockMvc.perform(get("/api/words")
+                        .param("userId", "1")
+                        .param("token", "tkn")
+                        .param("term", "hi")
+                        .param("language", "ENGLISH")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.term").value("hi"));
+    }


### PR DESCRIPTION
## Summary
- allow auth token in `token` query parameter via new `TokenResolver`
- share userId parsing with new `UserIdResolver`
- update `TokenAuthenticationInterceptor` and `AuthenticatedUserArgumentResolver`
- document new token option in README
- add tests for token query parameter

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688ba1bee21c8332869f44852965f7d1