### PR TITLE
[Fix] sanitize env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Glancy Backend is a Spring Boot service that powers the Glancy dictionary applic
 ## Setup
 
 1. Clone this repository.
-2. Create a `.env` file with `DB_PASSWORD`, `thirdparty.deepseek.api-key`, and `thirdparty.doubao.api-key` values.
+2. Create a `.env` file with `DB_PASSWORD`, `thirdparty.deepseek.api-key`, and `thirdparty.doubao.api-key` values. Optional `thirdparty.doubao.model` overrides the default model.
 3. Ensure MySQL is running with a database named `glancy_db`, matching credentials, and SSL certificates configured as `useSSL=true` requires.
 4. Use the `local` Spring profile if SSL is unavailable: `./mvnw spring-boot:run -Dspring.profiles.active=local`.
 5. Configure optional API base URLs in `application.yml` under the `thirdparty` section.

--- a/src/main/java/com/glancy/backend/client/DoubaoClient.java
+++ b/src/main/java/com/glancy/backend/client/DoubaoClient.java
@@ -6,7 +6,7 @@ import com.glancy.backend.entity.LlmModel;
 import com.glancy.backend.llm.llm.LLMClient;
 import com.glancy.backend.llm.model.ChatMessage;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
+import com.glancy.backend.config.DoubaoProperties;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
@@ -26,13 +26,13 @@ public class DoubaoClient implements LLMClient {
     private final RestTemplate restTemplate;
     private final String baseUrl;
     private final String apiKey;
+    private final String model;
 
-    public DoubaoClient(RestTemplate restTemplate,
-                        @Value("${thirdparty.doubao.base-url:https://ark.cn-beijing.volces.com/api/v3}") String baseUrl,
-                        @Value("${thirdparty.doubao.api-key:}") String apiKey) {
+    public DoubaoClient(RestTemplate restTemplate, DoubaoProperties properties) {
         this.restTemplate = restTemplate;
-        this.baseUrl = baseUrl;
-        this.apiKey = apiKey;
+        this.baseUrl = properties.getBaseUrl();
+        this.apiKey = properties.getApiKey() == null ? null : properties.getApiKey().trim();
+        this.model = properties.getModel();
         if (apiKey == null || apiKey.isBlank()) {
             log.warn("Doubao API key is empty");
         } else {
@@ -57,7 +57,7 @@ public class DoubaoClient implements LLMClient {
         }
 
         Map<String, Object> body = new HashMap<>();
-        body.put("model", LlmModel.DOUBAO_FLASH.getModelName());
+        body.put("model", model);
         body.put("temperature", temperature);
         body.put("stream", false);
 

--- a/src/main/java/com/glancy/backend/config/DoubaoProperties.java
+++ b/src/main/java/com/glancy/backend/config/DoubaoProperties.java
@@ -1,0 +1,19 @@
+package com.glancy.backend.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration for Doubao API access.
+ */
+@Data
+@ConfigurationProperties(prefix = "thirdparty.doubao")
+public class DoubaoProperties {
+    /** Base URL for Doubao API. */
+    private String baseUrl = "https://ark.cn-beijing.volces.com/api/v3";
+    /** API key for authentication. */
+    private String apiKey;
+    /** Doubao LLM model to use. */
+    private String model = "doubao-seed-1-6-flash-250715";
+}
+

--- a/src/main/java/com/glancy/backend/util/EnvLoader.java
+++ b/src/main/java/com/glancy/backend/util/EnvLoader.java
@@ -35,6 +35,10 @@ public final class EnvLoader {
                          String key = line.substring(0, idx).trim();
                          if (System.getProperty(key) == null && System.getenv(key) == null) {
                              String value = line.substring(idx + 1).trim();
+                             if ((value.startsWith("\"") && value.endsWith("\"")) ||
+                                 (value.startsWith("'") && value.endsWith("'"))) {
+                                 value = value.substring(1, value.length() - 1);
+                             }
                              System.setProperty(key, value);
                          }
                      }

--- a/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
+++ b/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
@@ -1,6 +1,7 @@
 package com.glancy.backend.client;
 
 import com.glancy.backend.llm.model.ChatMessage;
+import com.glancy.backend.config.DoubaoProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -26,7 +27,11 @@ class DoubaoClientTest {
     void setUp() {
         RestTemplate restTemplate = new RestTemplate();
         server = MockRestServiceServer.bindTo(restTemplate).build();
-        client = new DoubaoClient(restTemplate, "http://mock", "key");
+        DoubaoProperties properties = new DoubaoProperties();
+        properties.setBaseUrl("http://mock");
+        properties.setApiKey(" key ");
+        properties.setModel("test-model");
+        client = new DoubaoClient(restTemplate, properties);
     }
 
     @Test
@@ -35,6 +40,7 @@ class DoubaoClientTest {
         server.expect(requestTo("http://mock/v1/chat/completions"))
                 .andExpect(method(POST))
                 .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer key"))
+                .andExpect(jsonPath("$.model").value("test-model"))
                 .andRespond(withSuccess(json, MediaType.APPLICATION_JSON));
 
         String result = client.chat(List.of(new ChatMessage("user", "hi")), 0.5);

--- a/src/test/java/com/glancy/backend/util/EnvLoaderTest.java
+++ b/src/test/java/com/glancy/backend/util/EnvLoaderTest.java
@@ -1,0 +1,21 @@
+package com.glancy.backend.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class EnvLoaderTest {
+    @Test
+    void loadRemovesSurroundingQuotes() throws Exception {
+        Path file = Files.createTempFile("env", ".tmp");
+        Files.writeString(file, "TEST_KEY=\"secret\"");
+        assertNull(System.getProperty("TEST_KEY"));
+        EnvLoader.load(file);
+        assertEquals("secret", System.getProperty("TEST_KEY"));
+        Files.deleteIfExists(file);
+    }
+}


### PR DESCRIPTION
## Summary
- strip surrounding quotes when loading `.env` values
- add `EnvLoaderTest` to ensure values are sanitized

## Testing
- `./mvnw test -q` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688ba50d8a2c8332bc768ddde607064b