### PR TITLE
[Fix] correct Doubao endpoint path

### DIFF
--- a/src/main/java/com/glancy/backend/config/DoubaoProperties.java
+++ b/src/main/java/com/glancy/backend/config/DoubaoProperties.java
@@ -10,7 +10,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "thirdparty.doubao")
 public class DoubaoProperties {
     /** Base URL for Doubao API. */
-    private String baseUrl = "https://ark.cn-beijing.volces.com/api/v3";
+    private String baseUrl = "https://ark.cn-beijing.volces.com";
+    /** Endpoint path for chat completions. */
+    private String chatPath = "/api/v3/chat/completions";
     /** API key for authentication. */
     private String apiKey;
     /** Doubao LLM model to use. */

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,7 +51,8 @@ thirdparty:
         api-key: ''
 
     doubao:
-        base-url: https://ark.cn-beijing.volces.com/api/v3
+        base-url: https://ark.cn-beijing.volces.com
+        chat-path: /api/v3/chat/completions
         api-key: ''
 oss:
     endpoint: https://oss-cn-beijing.aliyuncs.com

--- a/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
+++ b/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
@@ -22,13 +22,15 @@ import org.springframework.http.HttpStatus;
 class DoubaoClientTest {
     private MockRestServiceServer server;
     private DoubaoClient client;
+    private DoubaoProperties properties;
 
     @BeforeEach
     void setUp() {
         RestTemplate restTemplate = new RestTemplate();
         server = MockRestServiceServer.bindTo(restTemplate).build();
-        DoubaoProperties properties = new DoubaoProperties();
+        properties = new DoubaoProperties();
         properties.setBaseUrl("http://mock");
+        properties.setChatPath("/api/v3/chat/completions");
         properties.setApiKey(" key ");
         properties.setModel("test-model");
         client = new DoubaoClient(restTemplate, properties);
@@ -37,7 +39,7 @@ class DoubaoClientTest {
     @Test
     void chatReturnsContent() {
         String json = "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"hi\"}}]}";
-        server.expect(requestTo("http://mock/v1/chat/completions"))
+        server.expect(requestTo("http://mock" + properties.getChatPath()))
                 .andExpect(method(POST))
                 .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer key"))
                 .andExpect(jsonPath("$.model").value("test-model"))
@@ -50,7 +52,7 @@ class DoubaoClientTest {
 
     @Test
     void chatUnauthorizedThrowsException() {
-        server.expect(requestTo("http://mock/v1/chat/completions"))
+        server.expect(requestTo("http://mock" + properties.getChatPath()))
                 .andExpect(method(POST))
                 .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
 


### PR DESCRIPTION
## Summary
- fix `DoubaoProperties` defaults based on SDK path
- sanitize base URL and path in `DoubaoClient`
- update application configuration and tests

## Testing
- `./mvnw test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688babedfb2083328b1a0a98c527fd39