### PR TITLE
[Fix] align notification logging with request DTO

### DIFF
--- a/src/main/java/com/glancy/backend/controller/NotificationController.java
+++ b/src/main/java/com/glancy/backend/controller/NotificationController.java
@@ -32,7 +32,7 @@ public class NotificationController {
      */
     @PostMapping("/system")
     public ResponseEntity<NotificationResponse> createSystem(@Valid @RequestBody NotificationRequest req) {
-        log.info("Creating system notification with title '{}'", req.getTitle());
+        log.info("Creating system notification with message '{}'", req.getMessage());
         NotificationResponse resp = notificationService.createSystemNotification(req);
         log.info("Created system notification {}", resp.getId());
         return new ResponseEntity<>(resp, HttpStatus.CREATED);
@@ -45,7 +45,7 @@ public class NotificationController {
     @PostMapping("/user/{userId}")
     public ResponseEntity<NotificationResponse> createUser(@PathVariable Long userId,
                                                            @Valid @RequestBody NotificationRequest req) {
-        log.info("Creating user notification for user {} with title '{}'", userId, req.getTitle());
+        log.info("Creating user notification for user {} with message '{}'", userId, req.getMessage());
         NotificationResponse resp = notificationService.createUserNotification(userId, req);
         log.info("Created user notification {} for user {}", resp.getId(), userId);
         return new ResponseEntity<>(resp, HttpStatus.CREATED);


### PR DESCRIPTION
## Summary
- replace obsolete title logs with message-based logs in NotificationController

## Testing
- `./mvnw test` *(fails: Network is unreachable while downloading Maven distribution)*
- `mvn test` *(fails: Non-resolvable parent POM due to network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_6890b355adb883328ae74169d02a8584