### PR TITLE
[Test] Add repository layer tests

### DIFF
--- a/src/test/java/com/glancy/backend/repository/ContactMessageRepositoryTest.java
+++ b/src/test/java/com/glancy/backend/repository/ContactMessageRepositoryTest.java
@@ -1,0 +1,27 @@
+package com.glancy.backend.repository;
+
+import com.glancy.backend.entity.ContactMessage;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class ContactMessageRepositoryTest {
+
+    @Autowired
+    private ContactMessageRepository contactMessageRepository;
+
+    @Test
+    void saveAndFind() {
+        ContactMessage msg = TestEntityFactory.contactMessage("alice");
+        contactMessageRepository.save(msg);
+
+        Optional<ContactMessage> found = contactMessageRepository.findById(msg.getId());
+        assertTrue(found.isPresent());
+        assertEquals("alice", found.get().getName());
+    }
+}

--- a/src/test/java/com/glancy/backend/repository/FaqRepositoryTest.java
+++ b/src/test/java/com/glancy/backend/repository/FaqRepositoryTest.java
@@ -1,0 +1,27 @@
+package com.glancy.backend.repository;
+
+import com.glancy.backend.entity.Faq;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class FaqRepositoryTest {
+
+    @Autowired
+    private FaqRepository faqRepository;
+
+    @Test
+    void saveAndRetrieve() {
+        Faq faq = TestEntityFactory.faq("q1");
+        faqRepository.save(faq);
+
+        Optional<Faq> found = faqRepository.findById(faq.getId());
+        assertTrue(found.isPresent());
+        assertEquals("q1", found.get().getQuestion());
+    }
+}

--- a/src/test/java/com/glancy/backend/repository/LoginDeviceRepositoryTest.java
+++ b/src/test/java/com/glancy/backend/repository/LoginDeviceRepositoryTest.java
@@ -1,0 +1,34 @@
+package com.glancy.backend.repository;
+
+import com.glancy.backend.entity.LoginDevice;
+import com.glancy.backend.entity.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class LoginDeviceRepositoryTest {
+
+    @Autowired
+    private LoginDeviceRepository loginDeviceRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void findByUserIdOrderByLoginTimeAsc() {
+        User user = userRepository.save(TestEntityFactory.user(30));
+        LoginDevice d1 = TestEntityFactory.loginDevice(user, "d1", LocalDateTime.now());
+        LoginDevice d2 = TestEntityFactory.loginDevice(user, "d2", LocalDateTime.now().plusMinutes(1));
+        loginDeviceRepository.save(d2);
+        loginDeviceRepository.save(d1);
+
+        List<LoginDevice> list = loginDeviceRepository.findByUserIdOrderByLoginTimeAsc(user.getId());
+        assertEquals("d1", list.get(0).getDeviceInfo());
+        assertEquals(2, list.size());
+    }
+}

--- a/src/test/java/com/glancy/backend/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/glancy/backend/repository/NotificationRepositoryTest.java
@@ -1,0 +1,42 @@
+package com.glancy.backend.repository;
+
+import com.glancy.backend.entity.Notification;
+import com.glancy.backend.entity.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class NotificationRepositoryTest {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void notificationQueries() {
+        User user = userRepository.save(TestEntityFactory.user(20));
+        Notification system = TestEntityFactory.notification(null, "sys", true, LocalDateTime.now().minusHours(1));
+        Notification userNote = TestEntityFactory.notification(user, "user", false, LocalDateTime.now());
+        notificationRepository.save(system);
+        notificationRepository.save(userNote);
+
+        List<Notification> systemList = notificationRepository.findBySystemLevelTrue();
+        assertEquals(1, systemList.size());
+
+        List<Notification> userList = notificationRepository.findByUserId(user.getId());
+        assertEquals(1, userList.size());
+
+        List<Notification> sortedUser = notificationRepository.findByUserIdOrderByCreatedAtDesc(user.getId());
+        assertEquals("user", sortedUser.get(0).getMessage());
+
+        List<Notification> sortedSystem = notificationRepository.findBySystemLevelTrueOrderByCreatedAtDesc();
+        assertEquals("sys", sortedSystem.get(0).getMessage());
+    }
+}

--- a/src/test/java/com/glancy/backend/repository/TestEntityFactory.java
+++ b/src/test/java/com/glancy/backend/repository/TestEntityFactory.java
@@ -1,0 +1,96 @@
+package com.glancy.backend.repository;
+
+import com.glancy.backend.entity.*;
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+/**
+ * Helper factory creating test entities with sensible defaults.
+ */
+final class TestEntityFactory {
+    private TestEntityFactory() {
+    }
+
+    static User user(int idx) {
+        User user = new User();
+        user.setUsername("user" + idx);
+        user.setPassword("pass" + idx);
+        user.setEmail("user" + idx + "@example.com");
+        user.setPhone("1000" + idx);
+        user.setMember(false);
+        return user;
+    }
+
+    static SearchRecord searchRecord(User user, String term, Language language, LocalDateTime createdAt) {
+        SearchRecord record = new SearchRecord();
+        record.setUser(user);
+        record.setTerm(term);
+        record.setLanguage(language);
+        record.setCreatedAt(createdAt);
+        return record;
+    }
+
+    static Word word(String term, Language language) {
+        Word word = new Word();
+        word.setTerm(term);
+        word.setLanguage(language);
+        word.setDefinitions(Collections.singletonList("def"));
+        return word;
+    }
+
+    static Notification notification(User user, String msg, boolean system, LocalDateTime createdAt) {
+        Notification n = new Notification();
+        n.setUser(user);
+        n.setMessage(msg);
+        n.setSystemLevel(system);
+        n.setCreatedAt(createdAt);
+        return n;
+    }
+
+    static ContactMessage contactMessage(String name) {
+        ContactMessage msg = new ContactMessage();
+        msg.setName(name);
+        msg.setEmail(name + "@example.com");
+        msg.setMessage("hello");
+        return msg;
+    }
+
+    static LoginDevice loginDevice(User user, String device, LocalDateTime time) {
+        LoginDevice deviceEntity = new LoginDevice();
+        deviceEntity.setUser(user);
+        deviceEntity.setDeviceInfo(device);
+        deviceEntity.setLoginTime(time);
+        return deviceEntity;
+    }
+
+    static UserPreference userPreference(User user) {
+        UserPreference pref = new UserPreference();
+        pref.setUser(user);
+        pref.setTheme("light");
+        pref.setSystemLanguage("en");
+        pref.setSearchLanguage("en");
+        return pref;
+    }
+
+    static ThirdPartyAccount thirdPartyAccount(User user, String provider, String externalId) {
+        ThirdPartyAccount tpa = new ThirdPartyAccount();
+        tpa.setUser(user);
+        tpa.setProvider(provider);
+        tpa.setExternalId(externalId);
+        return tpa;
+    }
+
+    static UserProfile userProfile(User user) {
+        UserProfile profile = new UserProfile();
+        profile.setUser(user);
+        profile.setAge(20);
+        return profile;
+    }
+
+    static Faq faq(String question) {
+        Faq faq = new Faq();
+        faq.setQuestion(question);
+        faq.setAnswer("answer");
+        return faq;
+    }
+}

--- a/src/test/java/com/glancy/backend/repository/ThirdPartyAccountRepositoryTest.java
+++ b/src/test/java/com/glancy/backend/repository/ThirdPartyAccountRepositoryTest.java
@@ -1,0 +1,31 @@
+package com.glancy.backend.repository;
+
+import com.glancy.backend.entity.ThirdPartyAccount;
+import com.glancy.backend.entity.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class ThirdPartyAccountRepositoryTest {
+
+    @Autowired
+    private ThirdPartyAccountRepository thirdPartyAccountRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void findByProviderAndExternalId() {
+        User user = userRepository.save(TestEntityFactory.user(50));
+        ThirdPartyAccount tpa = TestEntityFactory.thirdPartyAccount(user, "google", "ext123");
+        thirdPartyAccountRepository.save(tpa);
+
+        Optional<ThirdPartyAccount> found = thirdPartyAccountRepository.findByProviderAndExternalId("google", "ext123");
+        assertTrue(found.isPresent());
+        assertEquals(user.getId(), found.get().getUser().getId());
+    }
+}

--- a/src/test/java/com/glancy/backend/repository/UserPreferenceRepositoryTest.java
+++ b/src/test/java/com/glancy/backend/repository/UserPreferenceRepositoryTest.java
@@ -1,0 +1,31 @@
+package com.glancy.backend.repository;
+
+import com.glancy.backend.entity.User;
+import com.glancy.backend.entity.UserPreference;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class UserPreferenceRepositoryTest {
+
+    @Autowired
+    private UserPreferenceRepository userPreferenceRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void findByUserId() {
+        User user = userRepository.save(TestEntityFactory.user(40));
+        UserPreference pref = TestEntityFactory.userPreference(user);
+        userPreferenceRepository.save(pref);
+
+        Optional<UserPreference> found = userPreferenceRepository.findByUserId(user.getId());
+        assertTrue(found.isPresent());
+        assertEquals("light", found.get().getTheme());
+    }
+}

--- a/src/test/java/com/glancy/backend/repository/UserProfileRepositoryTest.java
+++ b/src/test/java/com/glancy/backend/repository/UserProfileRepositoryTest.java
@@ -1,0 +1,31 @@
+package com.glancy.backend.repository;
+
+import com.glancy.backend.entity.User;
+import com.glancy.backend.entity.UserProfile;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class UserProfileRepositoryTest {
+
+    @Autowired
+    private UserProfileRepository userProfileRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void findByUserId() {
+        User user = userRepository.save(TestEntityFactory.user(60));
+        UserProfile profile = TestEntityFactory.userProfile(user);
+        userProfileRepository.save(profile);
+
+        Optional<UserProfile> found = userProfileRepository.findByUserId(user.getId());
+        assertTrue(found.isPresent());
+        assertEquals(20, found.get().getAge());
+    }
+}

--- a/src/test/java/com/glancy/backend/repository/UserRepositoryTest.java
+++ b/src/test/java/com/glancy/backend/repository/UserRepositoryTest.java
@@ -1,0 +1,43 @@
+package com.glancy.backend.repository;
+
+import com.glancy.backend.entity.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void findByUsernameAndDeletedFalse() {
+        User user = TestEntityFactory.user(1);
+        userRepository.save(user);
+
+        Optional<User> found = userRepository.findByUsernameAndDeletedFalse("user1");
+        assertTrue(found.isPresent());
+        assertEquals("user1@example.com", found.get().getEmail());
+    }
+
+    @Test
+    void countAndLoginTokenQueries() {
+        User active = TestEntityFactory.user(2);
+        active.setMember(true);
+        active.setLoginToken("token123");
+        User deleted = TestEntityFactory.user(3);
+        deleted.setDeleted(true);
+        userRepository.save(active);
+        userRepository.save(deleted);
+
+        assertEquals(1, userRepository.countByDeletedFalse());
+        assertEquals(1, userRepository.countByDeletedTrue());
+        assertEquals(1, userRepository.countByDeletedFalseAndMemberTrue());
+        assertTrue(userRepository.findByLoginToken("token123").isPresent());
+    }
+}

--- a/src/test/java/com/glancy/backend/repository/WordRepositoryTest.java
+++ b/src/test/java/com/glancy/backend/repository/WordRepositoryTest.java
@@ -1,0 +1,28 @@
+package com.glancy.backend.repository;
+
+import com.glancy.backend.entity.Language;
+import com.glancy.backend.entity.Word;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class WordRepositoryTest {
+
+    @Autowired
+    private WordRepository wordRepository;
+
+    @Test
+    void findByTermAndLanguageAndDeletedFalse() {
+        Word word = TestEntityFactory.word("hello", Language.EN);
+        wordRepository.save(word);
+
+        Optional<Word> found = wordRepository.findByTermAndLanguageAndDeletedFalse("hello", Language.EN);
+        assertTrue(found.isPresent());
+        assertEquals("hello", found.get().getTerm());
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable `TestEntityFactory` to streamline creation of entities for repository tests
- cover all data repositories with integration tests verifying custom query behavior

## Testing
- `./mvnw test` *(failed: Network is unreachable)*
- `mvn test` *(failed: Non-resolvable parent POM: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_6890e809acb88332bd23f53176383a0a