### PR TITLE
[Feature] Add Checkstyle and Spotless code style checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,9 @@ jobs:
                   distribution: 'temurin'
                   java-version: '17'
 
+            - name: Code style check
+              run: ./mvnw -B spotless:check checkstyle:check
+
             - name: Build project
               run: ./mvnw -B clean package -DskipTests
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="Indentation">
+            <property name="basicOffset" value="4"/>
+            <property name="braceAdjustment" value="0"/>
+            <property name="caseIndent" value="4"/>
+            <property name="tabWidth" value="4"/>
+        </module>
+        <module name="LineLength">
+            <property name="max" value="120"/>
+        </module>
+    </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,46 @@
             <finalName>glancy-backend</finalName>
             <plugins>
                         <plugin>
+                                <groupId>com.diffplug.spotless</groupId>
+                                <artifactId>spotless-maven-plugin</artifactId>
+                                <version>2.43.0</version>
+                                <configuration>
+                                        <java>
+                                                <prettier>
+                                                        <devDependencies>
+                                                                <prettier>3.2.5</prettier>
+                                                                <prettier-plugin-java>2.5.1</prettier-plugin-java>
+                                                        </devDependencies>
+                                                        <configFile>${project.basedir}/spotless-config.json</configFile>
+                                                </prettier>
+                                        </java>
+                                        <format>
+                                                <name>yaml</name>
+                                                <includes>
+                                                        <include>**/*.yml</include>
+                                                        <include>**/*.yaml</include>
+                                                </includes>
+                                                <prettier>
+                                                        <devDependencies>
+                                                                <prettier>3.2.5</prettier>
+                                                        </devDependencies>
+                                                        <parser>yaml</parser>
+                                                        <configFile>${project.basedir}/spotless-config.json</configFile>
+                                                </prettier>
+                                        </format>
+                                </configuration>
+                        </plugin>
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-checkstyle-plugin</artifactId>
+                                <version>3.3.0</version>
+                                <configuration>
+                                        <configLocation>checkstyle.xml</configLocation>
+                                        <consoleOutput>true</consoleOutput>
+                                        <failOnViolation>true</failOnViolation>
+                                </configuration>
+                        </plugin>
+                        <plugin>
                                 <groupId>org.apache.maven.plugins</groupId>
                                 <artifactId>maven-compiler-plugin</artifactId>
                                 <configuration>

--- a/spotless-config.json
+++ b/spotless-config.json
@@ -1,0 +1,5 @@
+{
+    "printWidth": 120,
+    "tabWidth": 4,
+    "useTabs": false
+}


### PR DESCRIPTION
## Summary
- integrate Spotless and Checkstyle plugins in the Maven build (`spotless-config.json`, `checkstyle.xml`)
- enforce 4-space indentation and 120-column limit across Java and YAML
- run formatting and lint checks in the deploy workflow before building

## Testing
- `./mvnw spotless:check checkstyle:check` *(failed: Network is unreachable while downloading Maven artifacts)*
- `./mvnw test` *(failed: Network is unreachable while downloading Maven artifacts)*

## Notes
- Maven wrapper could not access remote repositories in this environment, so checks and tests were unable to run to completion.


------
https://chatgpt.com/codex/tasks/task_e_6890e841ba708332b0c874602045eaba