### PR TITLE
[Fix] Configure Prettier plugin for Java formatting

### DIFF
--- a/spotless-config.json
+++ b/spotless-config.json
@@ -1,5 +1,7 @@
 {
     "printWidth": 120,
     "tabWidth": 4,
-    "useTabs": false
+    "useTabs": false,
+    "plugins": ["prettier-plugin-java"]
 }
+


### PR DESCRIPTION
## Summary
- ensure Spotless loads prettier-plugin-java for Java files (`spotless-config.json`)

## Testing
- `./mvnw test` (fails: Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_689194077848833295a5fe1db276450c