### PR TITLE
[Fix] Align DoubaoClientTest formatting with style guide

### DIFF
--- a/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
+++ b/src/test/java/com/glancy/backend/client/DoubaoClientTest.java
@@ -1,23 +1,25 @@
 package com.glancy.backend.client;
 
-import com.glancy.backend.llm.model.ChatMessage;
-import com.glancy.backend.config.DoubaoProperties;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.client.MockRestServiceServer;
-import org.springframework.web.client.RestTemplate;
-
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.http.HttpMethod.POST;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.glancy.backend.config.DoubaoProperties;
+import com.glancy.backend.llm.model.ChatMessage;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
 
 class DoubaoClientTest {
     private MockRestServiceServer server;
@@ -39,7 +41,8 @@ class DoubaoClientTest {
     @Test
     void chatReturnsContent() {
         String json = "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"hi\"}}]}";
-        server.expect(requestTo("http://mock" + properties.getChatPath()))
+        server
+                .expect(requestTo("http://mock" + properties.getChatPath()))
                 .andExpect(method(POST))
                 .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer key"))
                 .andExpect(jsonPath("$.model").value("test-model"))
@@ -52,7 +55,8 @@ class DoubaoClientTest {
 
     @Test
     void chatUnauthorizedThrowsException() {
-        server.expect(requestTo("http://mock" + properties.getChatPath()))
+        server
+                .expect(requestTo("http://mock" + properties.getChatPath()))
                 .andExpect(method(POST))
                 .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
 


### PR DESCRIPTION
## Summary
- reorder static and regular imports in `DoubaoClientTest`
- format chained server expectations for readability

## Testing
- `mvn test` *(fails: Non-resolvable parent POM for com.glancy:glancy-backend:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4; Network is unreachable)*

## Notes
- `mvn spotless:apply` also failed with the same network issue

------
https://chatgpt.com/codex/tasks/task_e_68919727853c8332b8206e7d20eaa0da